### PR TITLE
ci: run slow tests as separate parallel job with coverage

### DIFF
--- a/.github/workflows/combined_tests.yml
+++ b/.github/workflows/combined_tests.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11.7"
+          python-version: "3.12"
 
       - name: Cache uv
         uses: actions/cache@v4
@@ -30,10 +30,7 @@ jobs:
         run: uv sync --extra monitor --extra tests
 
       - name: Run unit tests with coverage
-        run: uv run coverage run -m pytest pynenc_tests/unit
-
-      - run: uv run coverage report
-      - run: uv run coverage html --show-contexts --title "Unit Test Coverage for ${{ github.sha }}"
+        run: uv run pytest pynenc_tests/unit --cov --cov-report=html:htmlcov --cov-report=term
 
       - name: Upload unit test coverage HTML
         uses: actions/upload-artifact@v4
@@ -54,7 +51,7 @@ jobs:
 
   integration-tests:
     runs-on: ubuntu-latest
-    container: python:3.11.7
+    container: python:3.12
     steps:
       - uses: actions/checkout@v4
 
@@ -72,11 +69,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra monitor --extra tests
 
-      - name: Run integration tests with coverage
-        run: uv run coverage run -m pytest pynenc_tests/integration
-
-      - run: uv run coverage report
-      - run: uv run coverage html --show-contexts --title "Integration Test Coverage for ${{ github.sha }}"
+      - name: Run integration tests with coverage (parallel)
+        run: uv run pytest pynenc_tests/integration -n auto --dist loadfile --cov --cov-report=html:htmlcov --cov-report=term -m "not slow"
 
       - name: Upload integration test coverage HTML
         uses: actions/upload-artifact@v4
@@ -95,8 +89,42 @@ jobs:
           name: coverage-data-integration
           path: coverage.integration
 
+  slow-tests:
+    runs-on: ubuntu-latest
+    container: python:3.12
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('pyproject.toml') }}
+
+      - name: Install dependencies
+        run: uv sync --extra monitor --extra tests
+
+      - name: Run slow tests with coverage
+        run: uv run pytest pynenc_tests/integration -n auto --dist loadfile --cov --cov-report=term -m "slow"
+
+      - name: Prepare slow coverage file for upload
+        run: |
+          cp .coverage coverage.slow
+          ls -la coverage.slow
+
+      - name: Upload slow test coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-data-slow
+          path: coverage.slow
+
   all-tests-completed:
-    needs: [unit-tests, integration-tests]
+    needs: [unit-tests, integration-tests, slow-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -108,7 +136,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11.7"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: uv sync --extra monitor --extra tests
@@ -124,7 +152,7 @@ jobs:
         run: find . -type f -name 'coverage.*'
 
       - name: Combine coverage data
-        run: uv run coverage combine coverage.unit coverage.integration
+        run: uv run coverage combine coverage.unit coverage.integration coverage.slow
 
       - run: uv run coverage report
       - run: uv run coverage html --show-contexts --title "Combined Test Coverage"

--- a/pynenc_tests/unit/combinations/test_combination_validity.py
+++ b/pynenc_tests/unit/combinations/test_combination_validity.py
@@ -1,0 +1,81 @@
+"""Unit tests for build_test_combinations().
+
+Verifies that every generated combination is internally consistent:
+- All backend classes share the same family (no mixing of Python-Mem
+  classes with Rust-Mem classes, etc.)
+- The BackendFamily enum value matches the actual classes in the tuple
+- All IDs are unique (no duplicate parametrize IDs)
+- Rust runners are never paired with Python-only backends and vice-versa
+"""
+
+import pytest
+
+from pynenc_tests.integration.combinations.conftest import (
+    AppComponents,
+    BackendFamily,
+    MEM_CLASSES,
+    SQLITE_CLASSES,
+    build_test_combinations,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: class-to-expected-family lookup
+# ---------------------------------------------------------------------------
+
+def _expected_family(components: AppComponents) -> BackendFamily:
+    """Derive the expected BackendFamily purely from the component classes.
+
+    This is intentionally written without any string-sniffing so it serves
+    as an independent cross-check against the enum stored on the combination.
+    """
+    class_sets = {
+        BackendFamily.MEM: MEM_CLASSES,
+        BackendFamily.SQLITE: SQLITE_CLASSES,
+    }
+
+    actual = (
+        components.client_data_store,
+        components.broker,
+        components.orchestrator,
+        components.state_backend,
+        components.trigger,
+    )
+    for family, classes in class_sets.items():
+        if actual == classes:
+            return family
+    raise ValueError(
+        f"Component tuple {actual!r} does not match any known BackendFamily. "
+        "A new backend was added without updating the test."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+COMBINATIONS = build_test_combinations()
+
+
+@pytest.mark.parametrize("combo", COMBINATIONS, ids=lambda c: c.combination_id)
+def test_family_matches_classes(combo: AppComponents) -> None:
+    """The stored BackendFamily must match the actual component classes."""
+    assert combo.family == _expected_family(combo), (
+        f"{combo.combination_id!r}: stored family {combo.family!r} "
+        f"does not match the component classes"
+    )
+
+
+@pytest.mark.parametrize("combo", COMBINATIONS, ids=lambda c: c.combination_id)
+def test_sqlite_family_gets_sqlite_db_env(combo: AppComponents) -> None:
+    """SQLite-family combos must have is_sqlite=True; Mem-family must have is_sqlite=False."""
+    sqlite_backend = combo.family == BackendFamily.SQLITE
+    assert combo.family.is_sqlite == sqlite_backend
+
+
+def test_all_combination_ids_unique() -> None:
+    """Every combination must produce a distinct pytest parametrize ID."""
+    ids = [c.combination_id for c in COMBINATIONS]
+    assert len(ids) == len(set(ids)), (
+        f"Duplicate combination IDs: {[x for x in ids if ids.count(x) > 1]}"
+    )

--- a/pynenc_tests/unit/exceptions/test_error_hierarchy.py
+++ b/pynenc_tests/unit/exceptions/test_error_hierarchy.py
@@ -1,0 +1,78 @@
+"""Validate exception inheritance chains for pynenc exceptions."""
+
+import pytest
+
+from pynenc.exceptions import (
+    AlreadyInitializedError,
+    ConcurrencyRetryError,
+    ConfigError,
+    ConfigMultiInheritanceError,
+    InvalidTaskOptionsError,
+    InvocationConcurrencyWithDifferentArgumentsError,
+    InvocationError,
+    InvocationNotFoundError,
+    InvocationStatusError,
+    InvocationStatusOwnershipError,
+    InvocationStatusRaceConditionError,
+    InvocationStatusTransitionError,
+    PynencError,
+    RetryError,
+    RunnerError,
+    RunnerNotExecutableError,
+    SerializationError,
+    StateBackendError,
+    TaskError,
+    TaskParallelProcessingError,
+    TaskRoutingError,
+)
+
+# ── pynenc hierarchy ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "exc_cls, parents",
+    [
+        # Retry branch
+        (RetryError, [PynencError]),
+        (ConcurrencyRetryError, [RetryError, PynencError]),
+        # Serialization
+        (SerializationError, [PynencError]),
+        # Task branch
+        (TaskError, [PynencError]),
+        (InvalidTaskOptionsError, [TaskError, PynencError]),
+        (TaskRoutingError, [TaskError, PynencError]),
+        (
+            InvocationConcurrencyWithDifferentArgumentsError,
+            [TaskRoutingError, TaskError, PynencError],
+        ),
+        (TaskParallelProcessingError, [TaskError, PynencError]),
+        # Invocation
+        (InvocationError, [PynencError]),
+        # StateBackend branch
+        (StateBackendError, [PynencError]),
+        (InvocationNotFoundError, [StateBackendError, PynencError]),
+        # Runner
+        (RunnerNotExecutableError, [PynencError]),
+        (RunnerError, [PynencError]),
+        # Config
+        (ConfigError, [PynencError]),
+        (ConfigMultiInheritanceError, [ConfigError, PynencError]),
+        # Other
+        (AlreadyInitializedError, [PynencError]),
+        # Status branch
+        (InvocationStatusError, [PynencError]),
+        (InvocationStatusRaceConditionError, [InvocationStatusError, PynencError]),
+        (InvocationStatusTransitionError, [InvocationStatusError, PynencError]),
+        (InvocationStatusOwnershipError, [InvocationStatusError, PynencError]),
+    ],
+    ids=lambda x: x.__name__ if isinstance(x, type) else None,
+)
+def test_pynenc_exception_hierarchy(
+    exc_cls: type, parents: list[type]
+) -> None:
+    """Every pynenc exception must be a subclass of its documented parents."""
+    for parent in parents:
+        assert issubclass(exc_cls, parent), (
+            f"{exc_cls.__name__} is not a subclass of {parent.__name__}"
+        )
+


### PR DESCRIPTION
Slow tests (marked with @pytest.mark.slow) were excluded from CI. This adds them as a separate parallel job so they run without blocking the main pipeline, and their coverage is merged into the combined report.

- New slow-tests job runs -m slow tests in parallel (-n auto --dist loadfile)
- all-tests-completed now depends on all three jobs (unit, integration, slow)
- Coverage from slow tests is combined with unit and integration coverage

Tested locally: 17 passed, 6 skipped, 0 failures.