### PR TITLE
chore: release v0.1.2

### DIFF
--- a/.github/workflows/combined_tests.yml
+++ b/.github/workflows/combined_tests.yml
@@ -123,8 +123,30 @@ jobs:
           name: coverage-data-slow
           path: coverage.slow
 
+  unlocked-deps-test:
+    # Catches transitive dependency breakage (e.g. Starlette 1.x) that the
+    # lock file would hide.  Resolves deps fresh, like a downstream user would.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install with latest deps (no lock)
+        run: uv sync --extra monitor --extra tests --no-lock
+
+      - name: Run unit tests against latest deps
+        run: uv run pytest pynenc_tests/unit -x -q
+
   all-tests-completed:
-    needs: [unit-tests, integration-tests, slow-tests]
+    needs: [unit-tests, integration-tests, slow-tests, unlocked-deps-test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ cython_debug/
 docs/_build/
 # autodoc2 automodule
 docs/apidocs/
+
+# Investigation notes
+00_*.md

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - **test_add_and_get_ordered_histories**: fixed flaky timestamp collision by using explicit timestamps
 
+- **Fix pynmon Starlette 1.x template rendering crash**: migrated all `TemplateResponse` calls from the deprecated `(name, context_dict)` convention to the request-first `(request, name, context={...})` API. The old calling style was removed in Starlette 1.0, causing `TypeError: unhashable type: dict` on the home page and all other pynmon views. The new API is supported by Starlette 0.28+ so no minimum version bump is needed.
+
+- **Fix `pynenc monitor` crash during app hydration**: broadened exception handling in `import_app.py` module scanning so that lazy-loading modules (e.g. `six.moves` raising `ModuleNotFoundError` for `_gdbm`) no longer crash the entire discovery flow. Expected exceptions (`ImportError`, `AttributeError`, `TypeError`) are silently skipped; unexpected ones are logged at debug/warning level so they surface for debugging without crashing the monitor. This allows `Pynenc.from_info()` config-based fallback to execute when direct import fails. Improved `pynenc monitor` CLI output with actionable error hints.
+
 ### CI/Testing
 
 - **Parallel test execution**: added `pytest-xdist` and `pytest-cov`, integration tests now run with `-n auto --dist loadfile`
@@ -27,6 +31,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Pynmon fixture optimization**: reduced server startup sleep and increased retry count for faster CI
 - **Dropped Python 3.11 from compatibility matrix**: `test_compatibility.yml` now tests 3.12+ only
 - **New unit tests**: added `test_combination_validity.py` and `test_error_hierarchy.py`
+- **CI: unlocked-deps test job**: added a CI job that resolves dependencies without the lock file (`uv sync --no-lock`) to catch transitive dependency breakage before downstream users do
+- **Updated `uv.lock`**: upgraded FastAPI 0.118.3 → 0.136.0 and Starlette 0.48.0 → 1.0.0
 
 ## [0.1.1] - 2026-03-21
 

--- a/pynenc/cli/monitor_cli.py
+++ b/pynenc/cli/monitor_cli.py
@@ -69,15 +69,23 @@ def start_monitor_command(args: PynencCLINamespace) -> None:
         selected_app = args.app_instance
 
     print(
-        f"Starting monitoring for app: {selected_app.app_id if selected_app else 'None'}"
+        f"Starting monitoring for app: {selected_app.app_id if selected_app else 'auto-discover'}"
     )
-    start_monitor(
-        apps=apps,
-        selected_app=selected_app,
-        host=args.host,
-        port=args.port,
-        log_level=getattr(args, "log_level", None),
-    )
+    try:
+        start_monitor(
+            apps=apps,
+            selected_app=selected_app,
+            host=args.host,
+            port=args.port,
+            log_level=getattr(args, "log_level", None),
+        )
+    except ValueError as exc:
+        print(f"\nError: {exc}\n")
+        print("Hint: make sure the app's state backend is accessible from")
+        print("this environment (e.g. the SQLite DB exists).\n")
+        print("  • Specify the app explicitly:  pynenc --app tasks monitor")
+        print("  • Run with verbose mode for details:  pynenc -v monitor")
+        sys.exit(1)
 
 
 def _check_monitor_dependencies() -> bool:

--- a/pynenc/util/import_app.py
+++ b/pynenc/util/import_app.py
@@ -317,7 +317,16 @@ def _find_pynenc_by_id_in_module(
             continue
         try:
             attr = getattr(module, attr_name)
-        except (AttributeError, TypeError):
+        except (AttributeError, TypeError, ImportError):
+            continue
+        except Exception as e:
+            logger.debug(
+                "Unexpected %s accessing %s.%s — skipping",
+                type(e).__name__,
+                mod_name,
+                attr_name,
+                exc_info=True,
+            )
             continue
         if isinstance(attr, Pynenc) and attr.app_id == app_id:
             logger.info("Found app %s in module %s", app_id, mod_name)
@@ -340,5 +349,14 @@ def create_app_from_info(app_info: AppInfo) -> Pynenc | None:
     if app := _import_app_from_module(app_info):
         return app
     if app_info.module != "__main__":
-        return _scan_loaded_modules(app_info.app_id)
+        try:
+            return _scan_loaded_modules(app_info.app_id)
+        except (ImportError, AttributeError, TypeError):
+            logger.debug("Module scan failed for %s", app_info.app_id, exc_info=True)
+        except Exception:
+            logger.warning(
+                "Unexpected error scanning modules for %s",
+                app_info.app_id,
+                exc_info=True,
+            )
     return None

--- a/pynenc_tests/unit/pynmon/views/test_starlette_compat.py
+++ b/pynenc_tests/unit/pynmon/views/test_starlette_compat.py
@@ -1,0 +1,90 @@
+"""
+Regression tests for Starlette 1.x TemplateResponse compatibility.
+
+Starlette 1.x removed the deprecated (name, context_dict) calling convention
+for TemplateResponse. Pynmon must use the request-first API:
+  TemplateResponse(request, name, context={...})
+which is supported by both Starlette 0.28+ and 1.x.
+
+These tests verify that pynmon views render without TypeError on any
+supported Starlette version.
+"""
+
+import pytest
+
+pytest.importorskip("fastapi", reason="pynmon tests require monitor dependencies")
+pytest.importorskip("jinja2", reason="pynmon tests require monitor dependencies")
+
+# All imports below must come after pytest.importorskip calls
+# ruff: noqa: E402
+import warnings
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from pynmon.app import app as pynmon_app, setup_routes
+
+setup_routes()
+
+if TYPE_CHECKING:
+    from pynenc import Pynenc
+
+
+def test_home_route_returns_200_no_unhashable_dict(
+    app_instance: "Pynenc",
+) -> None:
+    """GET / returns 200 without TypeError: unhashable type: dict."""
+    with patch("pynmon.views.home.get_active_app", return_value=app_instance):
+        with patch(
+            "pynmon.views.home.get_all_apps",
+            return_value={app_instance.app_id: app_instance},
+        ):
+            client = TestClient(pynmon_app, raise_server_exceptions=True)
+            response = client.get("/")
+
+            assert response.status_code == 200
+            assert "text/html" in response.headers["content-type"]
+
+
+def test_home_page_renders_expected_html_content(
+    app_instance: "Pynenc",
+) -> None:
+    """Home page renders HTML with expected dashboard title and app info."""
+    with patch("pynmon.views.home.get_active_app", return_value=app_instance):
+        with patch(
+            "pynmon.views.home.get_all_apps",
+            return_value={app_instance.app_id: app_instance},
+        ):
+            client = TestClient(pynmon_app, raise_server_exceptions=True)
+            response = client.get("/")
+
+            content = response.text
+            assert "<html" in content
+            assert app_instance.app_id in content
+
+
+def test_template_response_uses_request_first_api(
+    app_instance: "Pynenc",
+) -> None:
+    """Verify no Starlette DeprecationWarning for old-style TemplateResponse."""
+    with patch("pynmon.views.home.get_active_app", return_value=app_instance):
+        with patch(
+            "pynmon.views.home.get_all_apps",
+            return_value={app_instance.app_id: app_instance},
+        ):
+            client = TestClient(pynmon_app, raise_server_exceptions=True)
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                response = client.get("/")
+
+            assert response.status_code == 200
+            starlette_deprecations = [
+                w
+                for w in caught
+                if issubclass(w.category, DeprecationWarning)
+                and "TemplateResponse" in str(w.message)
+            ]
+            assert starlette_deprecations == [], (
+                f"Old-style TemplateResponse detected: {starlette_deprecations}"
+            )

--- a/pynenc_tests/unit/util/test_scan_modules_resilience.py
+++ b/pynenc_tests/unit/util/test_scan_modules_resilience.py
@@ -1,0 +1,146 @@
+"""Tests for _find_pynenc_by_id_in_module and create_app_from_info resilience.
+
+Verifies that scanning arbitrary modules for Pynenc instances handles
+exceptions from lazy-loading modules (e.g. ``six.moves`` triggering
+``ModuleNotFoundError``) without crashing.
+"""
+
+import logging
+import types
+from unittest.mock import patch
+
+import pytest
+
+from pynenc.app import Pynenc
+from pynenc.app_info import AppInfo
+from pynenc.util import import_app
+
+
+# ---------------------------------------------------------------------------
+# _find_pynenc_by_id_in_module — getattr raises arbitrary exceptions
+# ---------------------------------------------------------------------------
+
+
+def test_getattr_raising_import_error_is_skipped() -> None:
+    """ModuleNotFoundError from lazy __getattr__ must not crash the scan."""
+    module = types.ModuleType("lazy_mod")
+
+    class _LazyDescriptor:
+        def __get__(self, obj: object, objtype: type | None = None) -> None:
+            raise ModuleNotFoundError("No module named '_gdbm'")
+
+    module.dbm_gnu = _LazyDescriptor()  # type: ignore[attr-defined]
+
+    result = import_app._find_pynenc_by_id_in_module(module, "lazy_mod", "any_id")
+    assert result is None
+
+
+def test_getattr_raising_runtime_error_is_skipped() -> None:
+    """RuntimeError from exotic __getattr__ must not crash the scan."""
+    module = types.ModuleType("weird_mod")
+
+    class _Boom:
+        def __get__(self, obj: object, objtype: type | None = None) -> None:
+            raise RuntimeError("descriptor chaos")
+
+    module.chaos = _Boom()  # type: ignore[attr-defined]
+
+    result = import_app._find_pynenc_by_id_in_module(module, "weird_mod", "any_id")
+    assert result is None
+
+
+def test_finds_matching_app_id() -> None:
+    """Normal case: module has a Pynenc instance with matching app_id."""
+    app = Pynenc()
+    module = types.ModuleType("good_mod")
+    module.app = app  # type: ignore[attr-defined]
+
+    result = import_app._find_pynenc_by_id_in_module(module, "good_mod", app.app_id)
+    assert result is app
+
+
+def test_skips_non_matching_app_id() -> None:
+    """Returns None when app_id doesn't match."""
+    app = Pynenc()
+    module = types.ModuleType("good_mod")
+    module.app = app  # type: ignore[attr-defined]
+
+    result = import_app._find_pynenc_by_id_in_module(
+        module, "good_mod", "nonexistent_id"
+    )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# create_app_from_info — _scan_loaded_modules failure must not prevent fallback
+# ---------------------------------------------------------------------------
+
+
+def test_create_app_from_info_returns_none_when_scan_raises() -> None:
+    """If _scan_loaded_modules raises ImportError, create_app_from_info returns None
+    so that Pynenc.from_info's config-based fallback can execute."""
+    app_info = AppInfo(
+        app_id="test_app",
+        module="some.module",
+        module_filepath=None,
+        app_variable=None,
+    )
+
+    with (
+        patch.object(import_app, "_import_app_from_module", return_value=None),
+        patch.object(
+            import_app,
+            "_scan_loaded_modules",
+            side_effect=ModuleNotFoundError("_gdbm"),
+        ),
+    ):
+        result = import_app.create_app_from_info(app_info)
+
+    assert result is None
+
+
+def test_create_app_from_info_logs_warning_on_unexpected_error(
+    caplog: "pytest.LogCaptureFixture",
+) -> None:
+    """Unexpected exceptions from _scan_loaded_modules are logged at WARNING
+    so they surface for debugging, but don't crash the caller."""
+    app_info = AppInfo(
+        app_id="test_app",
+        module="some.module",
+        module_filepath=None,
+        app_variable=None,
+    )
+
+    with (
+        patch.object(import_app, "_import_app_from_module", return_value=None),
+        patch.object(
+            import_app,
+            "_scan_loaded_modules",
+            side_effect=RuntimeError("totally unexpected"),
+        ),
+        caplog.at_level(logging.WARNING, logger="pynenc.util.import_app"),
+    ):
+        result = import_app.create_app_from_info(app_info)
+
+    assert result is None
+    assert "Unexpected error scanning modules" in caplog.text
+    assert "test_app" in caplog.text
+
+
+def test_create_app_from_info_succeeds_via_scan() -> None:
+    """Normal path: _scan_loaded_modules finds the app."""
+    app = Pynenc()
+    app_info = AppInfo(
+        app_id=app.app_id,
+        module="some.module",
+        module_filepath=None,
+        app_variable=None,
+    )
+
+    with (
+        patch.object(import_app, "_import_app_from_module", return_value=None),
+        patch.object(import_app, "_scan_loaded_modules", return_value=app),
+    ):
+        result = import_app.create_app_from_info(app_info)
+
+    assert result is app

--- a/pynmon/app.py
+++ b/pynmon/app.py
@@ -384,7 +384,8 @@ def hydrate_app_instances(
             else:
                 logger.warning(f"Failed to hydrate app: {app_id}")
         except Exception as e:
-            logger.error(f"Error hydrating app {app_id}: {e}", exc_info=True)
+            logger.warning("Could not hydrate app %s: %s", app_id, e)
+            logger.debug("Hydration traceback for %s:", app_id, exc_info=True)
 
     return instances
 

--- a/pynmon/util/view_helpers.py
+++ b/pynmon/util/view_helpers.py
@@ -37,12 +37,9 @@ def render_error_response(
     :return: HTMLResponse with error template
     """
     return templates.TemplateResponse(
+        request,
         "shared/error.html",
-        {
-            "request": request,
-            "title": title,
-            "message": message,
-        },
+        context={"title": title, "message": message},
         status_code=status_code,
     )
 

--- a/pynmon/views/broker.py
+++ b/pynmon/views/broker.py
@@ -20,9 +20,9 @@ async def broker_view(request: Request) -> HTMLResponse:
     }
 
     return templates.TemplateResponse(
+        request,
         "broker/overview.html",
-        {
-            "request": request,
+        context={
             "title": "Broker Monitor",
             "app_id": app.app_id,
             "broker_info": broker_info,
@@ -52,9 +52,9 @@ async def queue_view(
         app.broker.route_invocation(invocation.invocation_id)
 
     return templates.TemplateResponse(
+        request,
         "broker/queue.html",
-        {
-            "request": request,
+        context={
             "title": "Broker Queue",
             "app_id": app.app_id,
             "pending_invocations": pending_invocations,
@@ -72,13 +72,13 @@ async def refresh_broker(request: Request) -> HTMLResponse:
     pending_count = app.broker.count_invocations()
 
     return templates.TemplateResponse(
+        request,
         "broker/partials/info.html",
-        {
-            "request": request,
+        context={
             "broker_info": {
                 "type": app.broker.__class__.__name__,
                 "pending_count": pending_count,
-            },
+            }
         },
     )
 

--- a/pynmon/views/calls.py
+++ b/pynmon/views/calls.py
@@ -192,7 +192,7 @@ async def process_call_detail(
         logger.info(
             f"Rendering call detail template with {len(invocations)} invocations"
         )
-        return templates.TemplateResponse("calls/detail.html", context)
+        return templates.TemplateResponse(request, "calls/detail.html", context=context)
 
     except Exception as e:
         logger.exception(
@@ -220,7 +220,6 @@ def _create_call_detail_context(
     formatted_args, raw_args = format_serialized_arguments(serialized)
 
     return {
-        "request": request,
         "app_id": app.app_id,
         "call": target_call,
         "task": target_task,
@@ -262,9 +261,9 @@ async def call_detail_by_query(request: Request) -> HTMLResponse:
     except Exception as e:
         logger.exception(f"Unhandled exception in call_detail_by_query: {str(e)}")
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
+            context={
                 "title": "Unexpected Error",
                 "message": f"An unexpected error occurred: {str(e)}",
             },

--- a/pynmon/views/client_data_store.py
+++ b/pynmon/views/client_data_store.py
@@ -34,9 +34,9 @@ async def client_data_view(request: Request) -> HTMLResponse:
             f"Rendering client data store template in {time.time() - start_time:.2f}s"
         )
         return templates.TemplateResponse(
+            request,
             "client_data_store/overview.html",
-            {
-                "request": request,
+            context={
                 "title": "Client Data Store Monitor",
                 "app_id": app.app_id,
                 "client_data_store_info": client_data_store_info,
@@ -45,9 +45,9 @@ async def client_data_view(request: Request) -> HTMLResponse:
     except Exception as e:
         logger.exception(f"Error in client_data_view: {str(e)}")
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
+            context={
                 "title": "Error",
                 "message": f"An error occurred in the client data store view: {str(e)}",
             },

--- a/pynmon/views/family_tree.py
+++ b/pynmon/views/family_tree.py
@@ -75,9 +75,9 @@ async def invocation_family_tree(
     svg_content = await asyncio.to_thread(_build_svg, invocation_id, expand_ids)
     template = "partials/family_tree_bare.html" if bare else "partials/family_tree.html"
     return templates.TemplateResponse(
+        request,
         template,
-        {
-            "request": request,
+        context={
             "family_tree_svg": svg_content,
         },
     )

--- a/pynmon/views/home.py
+++ b/pynmon/views/home.py
@@ -132,9 +132,9 @@ async def index(request: Request) -> HTMLResponse:
 
     if not all_apps or not active_app:
         return templates.TemplateResponse(
+            request,
             "critical_error.html",
-            {
-                "request": request,
+            context={
                 "title": "No App Configured",
                 "message": "No Pynenc application is configured for monitoring.",
             },
@@ -156,9 +156,9 @@ async def index(request: Request) -> HTMLResponse:
     registered_tasks = len(active_app.tasks)
 
     return templates.TemplateResponse(
+        request,
         "index.html",
-        {
-            "request": request,
+        context={
             "app_id": active_app.app_id,
             "all_apps": list(all_apps.keys()),
             "components": components,

--- a/pynmon/views/invocations.py
+++ b/pynmon/views/invocations.py
@@ -128,9 +128,9 @@ async def invocations_list(
     )
 
     return templates.TemplateResponse(
+        request,
         "invocations/list.html",
-        {
-            "request": request,
+        context={
             "title": "Invocations Monitor",
             "app_id": app.app_id,
             "invocations": all_invocations,
@@ -423,9 +423,9 @@ async def invocations_timeline(
         )
 
         return templates.TemplateResponse(
+            request,
             "invocations/timeline.html",
-            {
-                "request": request,
+            context={
                 "title": "Invocations Timeline",
                 "app_id": app.app_id,
                 "svg_content": svg_content,
@@ -449,9 +449,9 @@ async def invocations_timeline(
     except Exception as e:
         logger.exception(f"Error in invocations_timeline: {str(e)}")
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
+            context={
                 "title": "Error",
                 "message": f"An error occurred while generating the timeline: {str(e)}",
             },
@@ -662,9 +662,9 @@ async def invocation_detail(
             f"Rendering invocation detail template in {time.time() - start_time:.2f}s"
         )
         return templates.TemplateResponse(
+            request,
             "invocations/detail.html",
-            {
-                "request": request,
+            context={
                 "title": "Invocation Details",
                 "app_id": app.app_id,
                 "invocation": invocation,
@@ -685,9 +685,9 @@ async def invocation_detail(
     except InvocationNotFoundError:
         logger.warning(f"No invocation found with ID: {invocation_id}")
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
+            context={
                 "title": "Invocation Not Found",
                 "message": f"No invocation found with ID: {invocation_id}",
             },
@@ -696,12 +696,9 @@ async def invocation_detail(
     except Exception as e:
         logger.exception(f"Unexpected error in invocation_detail: {str(e)}")
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
-                "title": "Error",
-                "message": f"An error occurred: {str(e)}",
-            },
+            context={"title": "Error", "message": f"An error occurred: {str(e)}"},
             status_code=500,
         )
     finally:
@@ -913,9 +910,7 @@ async def invocations_table(
     all_invocations = await asyncio.to_thread(_fetch_table_invocations)
 
     return templates.TemplateResponse(
+        request,
         "invocations/partials/table.html",
-        {
-            "request": request,
-            "invocations": all_invocations,
-        },
+        context={"invocations": all_invocations},
     )

--- a/pynmon/views/log_explorer.py
+++ b/pynmon/views/log_explorer.py
@@ -116,9 +116,9 @@ async def log_explorer(
     app = get_pynenc_instance()
     analysis = await _analyse_logs(app, log) if log.strip() else None
     return templates.TemplateResponse(
+        request,
         "log_explorer/index.html",
-        {
-            "request": request,
+        context={
             "title": "Log Explorer",
             "app_id": app.app_id,
             "log": log,

--- a/pynmon/views/orchestrator.py
+++ b/pynmon/views/orchestrator.py
@@ -72,9 +72,9 @@ async def orchestrator_view(request: Request) -> HTMLResponse:
     active_runners = await asyncio.to_thread(app.orchestrator.get_active_runners)
 
     return templates.TemplateResponse(
+        request,
         "orchestrator/overview.html",
-        {
-            "request": request,
+        context={
             "title": "Orchestrator Monitor",
             "app_id": app.app_id,
             "orchestrator_info": orchestrator_info,
@@ -99,9 +99,9 @@ async def refresh_orchestrator(request: Request) -> HTMLResponse:
     )
 
     return templates.TemplateResponse(
+        request,
         "orchestrator/partials/stats.html",
-        {
-            "request": request,
+        context={
             "status_counts": status_counts,
             "blocking_invocations": blocking_invocations,
         },

--- a/pynmon/views/runner.py
+++ b/pynmon/views/runner.py
@@ -36,12 +36,9 @@ async def runners_index(request: Request) -> HTMLResponse:
         runners_info["error"] = str(e)
 
     return templates.TemplateResponse(
+        request,
         "runners.html",
-        {
-            "request": request,
-            "runners_info": runners_info,
-            "app_id": pynenc.app_id,
-        },
+        context={"runners_info": runners_info, "app_id": pynenc.app_id},
     )
 
 
@@ -58,13 +55,15 @@ async def refresh_runners(request: Request) -> HTMLResponse:
             runners = await pynenc.broker.get_runners()
         else:
             return templates.TemplateResponse(
+                request,
                 "components/not_implemented.html",
-                {"request": request, "feature": "Runner listing"},
+                context={"feature": "Runner listing"},
             )
     except Exception as e:
         error = str(e)
 
     return templates.TemplateResponse(
+        request,
         "components/runner_list.html",
-        {"request": request, "runners": runners, "error": error},
+        context={"runners": runners, "error": error},
     )

--- a/pynmon/views/runners.py
+++ b/pynmon/views/runners.py
@@ -126,9 +126,9 @@ async def runners_view(request: Request) -> HTMLResponse:
     runner_config = _collect_runner_config(app)
 
     return templates.TemplateResponse(
+        request,
         "runners/overview.html",
-        {
-            "request": request,
+        context={
             "title": "Active Runners",
             "app_id": app.app_id,
             "enriched_runners": enriched_runners,
@@ -157,11 +157,9 @@ async def refresh_runners(request: Request) -> HTMLResponse:
     ]
 
     return templates.TemplateResponse(
+        request,
         "runners/partials/runners_table.html",
-        {
-            "request": request,
-            "enriched_runners": enriched_runners,
-        },
+        context={"enriched_runners": enriched_runners},
     )
 
 
@@ -194,9 +192,9 @@ async def runner_detail(request: Request, runner_id: str) -> HTMLResponse:
         }
 
     return templates.TemplateResponse(
+        request,
         "runners/detail.html",
-        {
-            "request": request,
+        context={
             "title": f"Runner {runner_id[:8]}",
             "app_id": app.app_id,
             "runner_info": runner_info,
@@ -240,9 +238,9 @@ async def atomic_service_timeline(request: Request) -> HTMLResponse:
             )
 
     return templates.TemplateResponse(
+        request,
         "runners/atomic_service_timeline.html",
-        {
-            "request": request,
+        context={
             "title": "Atomic Service Timeline",
             "app_id": app.app_id,
             "timeline_data": timeline_data,

--- a/pynmon/views/state_backend.py
+++ b/pynmon/views/state_backend.py
@@ -35,9 +35,9 @@ async def state_backend_view(request: Request) -> HTMLResponse:
             f"Rendering state backend template in {time.time() - start_time:.2f}s"
         )
         return templates.TemplateResponse(
+            request,
             "state_backend/overview.html",
-            {
-                "request": request,
+            context={
                 "title": "State Backend Monitor",
                 "app_id": app.app_id,
                 "state_backend_info": state_backend_info,
@@ -47,9 +47,9 @@ async def state_backend_view(request: Request) -> HTMLResponse:
     except Exception as e:
         logger.exception(f"Error in state_backend_view: {str(e)}")
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
+            context={
                 "title": "Error",
                 "message": f"An error occurred in the state backend view: {str(e)}",
             },

--- a/pynmon/views/tasks.py
+++ b/pynmon/views/tasks.py
@@ -70,13 +70,9 @@ async def tasks_list(request: Request) -> HTMLResponse:
     logger.info(f"Found {len(tasks)} tasks")
 
     return templates.TemplateResponse(
+        request,
         "tasks/list.html",
-        {
-            "request": request,
-            "title": "Tasks Monitor",
-            "app_id": app.app_id,
-            "tasks": tasks,
-        },
+        context={"title": "Tasks Monitor", "app_id": app.app_id, "tasks": tasks},
     )
 
 
@@ -91,11 +87,9 @@ async def refresh_tasks_list(request: Request) -> HTMLResponse:
     logger.info(f"Found {len(tasks)} tasks")
 
     return templates.TemplateResponse(
+        request,
         "tasks/partials/list_content.html",
-        {
-            "request": request,
-            "tasks": tasks,
-        },
+        context={"tasks": tasks},
     )
 
 
@@ -104,9 +98,9 @@ async def task_detail(request: Request, task_id_key: str) -> HTMLResponse:
     """Display detailed information about a specific task."""
     if not task_id_key:
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
+            context={
                 "title": "Missing Task ID",
                 "message": "No task_id was provided. Please check the URL and try again.",
             },
@@ -118,9 +112,9 @@ async def task_detail(request: Request, task_id_key: str) -> HTMLResponse:
     except ValueError as e:
         logger.warning(f"Invalid task ID format: {task_id_key} - {str(e)}")
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
+            context={
                 "title": "Invalid Task ID Format",
                 "message": f"The provided task ID is not properly formatted: {str(e)}",
             },
@@ -141,9 +135,9 @@ async def task_detail(request: Request, task_id_key: str) -> HTMLResponse:
                 f"No task found with ID: {task_id} - {type(e).__name__}: {e}"
             )
             return templates.TemplateResponse(
+                request,
                 "shared/error.html",
-                {
-                    "request": request,
+                context={
                     "title": "Task Not Found",
                     "message": f"No task found with ID: {task_id}",
                 },
@@ -153,9 +147,9 @@ async def task_detail(request: Request, task_id_key: str) -> HTMLResponse:
         if not task:
             logger.warning(f"No task found with ID: {task_id}")
             return templates.TemplateResponse(
+                request,
                 "shared/error.html",
-                {
-                    "request": request,
+                context={
                     "title": "Task Not Found",
                     "message": f"No task found with ID: {task_id}",
                 },
@@ -171,9 +165,9 @@ async def task_detail(request: Request, task_id_key: str) -> HTMLResponse:
 
         logger.info(f"Rendering template with {len(calls)} calls")
         return templates.TemplateResponse(
+            request,
             "tasks/detail.html",
-            {
-                "request": request,
+            context={
                 "title": "Task Details",
                 "app_id": app.app_id,
                 "task": task,
@@ -184,12 +178,9 @@ async def task_detail(request: Request, task_id_key: str) -> HTMLResponse:
     except Exception as e:
         logger.exception(f"Unexpected error in task_detail: {str(e)}")
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
-                "title": "Error",
-                "message": f"An error occurred: {str(e)}",
-            },
+            context={"title": "Error", "message": f"An error occurred: {str(e)}"},
             status_code=500,
         )
     finally:

--- a/pynmon/views/workflows.py
+++ b/pynmon/views/workflows.py
@@ -51,9 +51,9 @@ async def workflows_list(request: Request) -> HTMLResponse:
         workflows_with_runs = []
 
     return templates.TemplateResponse(
+        request,
         "workflows/list.html",
-        {
-            "request": request,
+        context={
             "title": "Workflows Monitor",
             "app_id": app.app_id,
             "workflows": workflows_with_runs,
@@ -91,11 +91,9 @@ async def refresh_workflows_list(request: Request) -> HTMLResponse:
         workflows_with_runs = []
 
     return templates.TemplateResponse(
+        request,
         "workflows/partials/list_content.html",
-        {
-            "request": request,
-            "workflows": workflows_with_runs,
-        },
+        context={"workflows": workflows_with_runs},
     )
 
 
@@ -120,9 +118,9 @@ async def workflow_runs_list(request: Request) -> HTMLResponse:
         sorted_runs = []
 
     return templates.TemplateResponse(
+        request,
         "workflows/runs.html",
-        {
-            "request": request,
+        context={
             "title": "Workflow Runs",
             "app_id": app.app_id,
             "workflow_runs": sorted_runs,
@@ -151,11 +149,9 @@ async def refresh_workflow_runs_list(request: Request) -> HTMLResponse:
         sorted_runs = []
 
     return templates.TemplateResponse(
+        request,
         "workflows/partials/runs_content.html",
-        {
-            "request": request,
-            "workflow_runs": sorted_runs,
-        },
+        context={"workflow_runs": sorted_runs},
     )
 
 
@@ -186,9 +182,9 @@ async def workflow_detail(request: Request, workflow_type_key: str) -> HTMLRespo
         task_extra = format_task_extra_info(task) if task else None
 
         return templates.TemplateResponse(
+            request,
             "workflows/detail.html",
-            {
-                "request": request,
+            context={
                 "title": "Workflow Details",
                 "app_id": app.app_id,
                 "workflow_type": workflow_type,
@@ -204,9 +200,9 @@ async def workflow_detail(request: Request, workflow_type_key: str) -> HTMLRespo
         )
 
         return templates.TemplateResponse(
+            request,
             "error.html",
-            {
-                "request": request,
+            context={
                 "title": "Error",
                 "app_id": app.app_id,
                 "error_title": "Workflow Not Found",
@@ -243,9 +239,9 @@ async def refresh_workflow_detail(
         task_extra = format_task_extra_info(task) if task else None
 
         return templates.TemplateResponse(
+            request,
             "workflows/partials/detail_content.html",
-            {
-                "request": request,
+            context={
                 "workflow_type": workflow_type,
                 "workflow_runs": sorted_runs,
                 "task": task,


### PR DESCRIPTION
## Release v0.1.2

### Fixed
- **Fix pynmon Starlette 1.x template rendering crash**: migrated all `TemplateResponse` calls from the deprecated `(name, context_dict)` convention to the request-first `(request, name, context={...})` API
- **Fix `pynenc monitor` crash during app hydration**: broadened exception handling in `import_app.py` module scanning so lazy-loading modules no longer crash the discovery flow. Improved CLI output with actionable error hints.

### Changed
- **CI: unlocked-deps test job**: added a CI job that resolves dependencies without the lock file (`uv sync --no-lock`) to catch transitive dependency breakage
- **Updated `uv.lock`**: upgraded FastAPI 0.118.3 → 0.136.0 and Starlette 0.48.0 → 1.0.0

### Tests
- Added Starlette compat regression tests
- Added module scan resilience tests