### PR TITLE
chore: release v0.2.1

### DIFF
--- a/.github/workflows/combined_tests.yml
+++ b/.github/workflows/combined_tests.yml
@@ -123,8 +123,32 @@ jobs:
           name: coverage-data-slow
           path: coverage.slow
 
+  unlocked-deps-test:
+    # Catches transitive dependency breakage (e.g. Starlette 1.x) that the
+    # lock file would hide.  Resolves deps fresh, like a downstream user would.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install with latest deps (no lock)
+        run: |
+          rm -f uv.lock
+          uv sync --extra monitor --extra tests
+
+      - name: Run unit tests against latest deps
+        run: uv run pytest pynenc_tests/unit -x -q
+
   all-tests-completed:
-    needs: [unit-tests, integration-tests, slow-tests]
+    needs: [unit-tests, integration-tests, slow-tests, unlocked-deps-test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ cython_debug/
 docs/_build/
 # autodoc2 automodule
 docs/apidocs/
+
+# Investigation notes
+00_*.md

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ docs:
 	@echo "Building documentation..."
 	rm -rf docs/_build
 	uv sync --all-extras --group docs
-        uv run --group docs python -m sphinx -b html docs docs/_build/html
+	uv run --group docs python -m sphinx -b html docs docs/_build/html
 	@echo "Docs built — open docs/_build/html/index.html in a browser."
 
 .PHONY: docs-serve

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - **Fix `pynenc monitor` crash during app hydration**: broadened exception handling in `import_app.py` module scanning so that lazy-loading modules (e.g. `six.moves` raising `ModuleNotFoundError` for `_gdbm`) no longer crash the entire discovery flow. Expected exceptions (`ImportError`, `AttributeError`, `TypeError`) are silently skipped; unexpected ones are logged at debug/warning level so they surface for debugging without crashing the monitor. This allows `Pynenc.from_info()` config-based fallback to execute when direct import fails. Improved `pynenc monitor` CLI output with actionable error hints.
 
+- **Fix `pynenc monitor` invocations tab crash**: `extract_module_info` was using `app.__module__` which always resolves to `"pynenc.app"` (where the class is defined) instead of the user module where `app = Pynenc()` was written. This caused `AppInfo` to store the wrong module name in the database, making `_import_app_from_module` fail when the monitor later tried to deserialize invocations. Rewrote `extract_module_info` to scan loaded user modules by identity and return a 3-tuple `(module_name, module_filepath, app_variable)`. Updated `AppInfo.from_app` to use the discovered module name. Also ensured CWD is on `sys.path` in `start_monitor_command` so user task modules are importable when running via the `pynenc` entry point.
+
 ### Changed
 
 - **CI: unlocked-deps test job**: added a CI job that resolves dependencies without the lock file (`uv sync --no-lock`) to catch transitive dependency breakage before downstream users do

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-04-19
+
+### Fixed
+
+- **Fix pynmon Starlette 1.x template rendering crash**: migrated all `TemplateResponse` calls from the deprecated `(name, context_dict)` convention to the request-first `(request, name, context={...})` API. The old calling style was removed in Starlette 1.0, causing `TypeError: unhashable type: dict` on the home page and all other pynmon views. The new API is supported by Starlette 0.28+ so no minimum version bump is needed.
+
+- **Fix `pynenc monitor` crash during app hydration**: broadened exception handling in `import_app.py` module scanning so that lazy-loading modules (e.g. `six.moves` raising `ModuleNotFoundError` for `_gdbm`) no longer crash the entire discovery flow. Expected exceptions (`ImportError`, `AttributeError`, `TypeError`) are silently skipped; unexpected ones are logged at debug/warning level so they surface for debugging without crashing the monitor. This allows `Pynenc.from_info()` config-based fallback to execute when direct import fails. Improved `pynenc monitor` CLI output with actionable error hints.
+
+### Changed
+
+- **CI: unlocked-deps test job**: added a CI job that resolves dependencies without the lock file (`uv sync --no-lock`) to catch transitive dependency breakage before downstream users do
+- **Updated `uv.lock`**: upgraded FastAPI 0.118.3 → 0.136.0 and Starlette 0.48.0 → 1.0.0
+
 ## [0.2.0] - 2026-04-08
 
 ### Breaking

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - **CI: unlocked-deps test job**: added a CI job that resolves dependencies without the lock file (`uv sync --no-lock`) to catch transitive dependency breakage before downstream users do
 - **Updated `uv.lock`**: upgraded FastAPI 0.118.3 → 0.136.0 and Starlette 0.48.0 → 1.0.0
+- **Dependency bumps**: black 23.11.0 → 26.3.1, sphinx `>=8.0,<9` → `>=8.0,<10`
 
 ## [0.2.0] - 2026-04-08
 

--- a/pynenc/app_info.py
+++ b/pynenc/app_info.py
@@ -58,12 +58,12 @@ class AppInfo:
         """
         from pynenc.util.import_app import extract_module_info
 
-        module_filepath, app_variable = extract_module_info(app)
+        module_name, module_filepath, app_variable = extract_module_info(app)
         return cls(
             app_id=app.app_id,
             config_values=app.config_values,
             config_filepath=app.config_filepath,
-            module=app.__module__,
+            module=module_name or app.__module__,
             module_filepath=module_filepath,
             app_variable=app_variable,
         )

--- a/pynenc/cli/monitor_cli.py
+++ b/pynenc/cli/monitor_cli.py
@@ -1,5 +1,6 @@
 import argparse
 import importlib.util
+import os
 import sys
 from typing import TYPE_CHECKING
 
@@ -33,6 +34,12 @@ def add_monitor_subparser(subparsers: argparse._SubParsersAction) -> None:
 
 def start_monitor_command(args: PynencCLINamespace) -> None:
     """Execute the monitor command, starting the web interface."""
+    # Ensure CWD is on sys.path so user task modules (e.g. tasks.py) are
+    # importable when the monitor deserializes invocations.
+    cwd = os.getcwd()
+    if cwd not in sys.path:
+        sys.path.insert(0, cwd)
+
     # Check Python version compatibility
     if sys.version_info >= (3, 13):
         print("Error: Pynmon monitoring UI requires Python <3.13")

--- a/pynenc/cli/monitor_cli.py
+++ b/pynenc/cli/monitor_cli.py
@@ -69,15 +69,23 @@ def start_monitor_command(args: PynencCLINamespace) -> None:
         selected_app = args.app_instance
 
     print(
-        f"Starting monitoring for app: {selected_app.app_id if selected_app else 'None'}"
+        f"Starting monitoring for app: {selected_app.app_id if selected_app else 'auto-discover'}"
     )
-    start_monitor(
-        apps=apps,
-        selected_app=selected_app,
-        host=args.host,
-        port=args.port,
-        log_level=getattr(args, "log_level", None),
-    )
+    try:
+        start_monitor(
+            apps=apps,
+            selected_app=selected_app,
+            host=args.host,
+            port=args.port,
+            log_level=getattr(args, "log_level", None),
+        )
+    except ValueError as exc:
+        print(f"\nError: {exc}\n")
+        print("Hint: make sure the app's state backend is accessible from")
+        print("this environment (e.g. the SQLite DB exists).\n")
+        print("  • Specify the app explicitly:  pynenc --app tasks monitor")
+        print("  • Run with verbose mode for details:  pynenc -v monitor")
+        sys.exit(1)
 
 
 def _check_monitor_dependencies() -> bool:

--- a/pynenc/util/import_app.py
+++ b/pynenc/util/import_app.py
@@ -16,7 +16,6 @@ Key components:
 
 import importlib
 import importlib.util
-import inspect
 import logging
 import os
 import sys
@@ -226,31 +225,84 @@ def find_app_instance(app_spec: str | None) -> Pynenc:
     return _find_pynenc_in_module(module)
 
 
-def extract_module_info(app: "Pynenc") -> tuple[str | None, str | None]:
+def _find_app_in_user_modules(
+    app: "Pynenc",
+) -> tuple[str, str, str] | None:
     """
-    Extract module filepath and app variable name from a Pynenc instance.
+    Scan loaded non-pynenc modules for one that holds ``app`` as a top-level variable.
+
+    The ``Pynenc`` class is defined in ``pynenc.app``, so ``app.__module__``
+    always returns ``"pynenc.app"`` — not the user module where
+    ``app = Pynenc()`` was written.  This helper finds the correct user module
+    by identity-checking attributes across all loaded modules.
+
+    :param Pynenc app: The application instance to locate.
+    :return: ``(module_name, module_filepath, variable_name)`` or ``None``.
+    """
+    for mod_name, mod in list(sys.modules.items()):
+        if mod_name.startswith("_") or mod_name == "__main__":
+            continue
+        if mod_name.startswith("pynenc.") or mod_name == "pynenc":
+            continue
+        if not hasattr(mod, "__file__") or mod.__file__ is None:
+            continue
+        if variable := _find_app_variable_in_module(mod, app):
+            return mod_name, mod.__file__, variable
+    return None
+
+
+def _find_app_variable_in_module(module: types.ModuleType, app: "Pynenc") -> str | None:
+    """
+    Return the public attribute name in ``module`` whose value is ``app``.
+
+    :param types.ModuleType module: Module to inspect.
+    :param Pynenc app: The instance to match by identity.
+    :return: Attribute name, or ``None`` if not found.
+    """
+    try:
+        names = dir(module)
+    except (ImportError, TypeError):
+        return None
+    for name in names:
+        if name.startswith("_"):
+            continue
+        try:
+            if getattr(module, name) is app:
+                return name
+        except (AttributeError, TypeError, ImportError):
+            continue
+        except Exception:
+            continue
+    return None
+
+
+def extract_module_info(
+    app: "Pynenc",
+) -> tuple[str | None, str | None, str | None]:
+    """
+    Extract module name, filepath, and app variable name from a Pynenc instance.
+
+    Scans loaded user modules to find the one that holds ``app`` as a
+    top-level variable.  Falls back to ``app.__module__`` when no user
+    module claims it (e.g. during unit tests).
 
     :param Pynenc app: Pynenc application instance.
-    :return: Tuple of (module_filepath, app_variable_name).
+    :return: Tuple of (module_name, module_filepath, app_variable_name).
     """
-    module_filepath: str | None = None
-    app_variable: str | None = None
-
     try:
-        if app.__module__ == "__main__":
-            return None, None
+        if result := _find_app_in_user_modules(app):
+            return result
 
-        module = sys.modules.get(app.__module__)
-        if module and hasattr(module, "__file__"):
-            module_filepath = module.__file__
-            for name, val in inspect.getmembers(module):
-                if val is app and not name.startswith("_"):
-                    app_variable = name
-                    break
+        # Fallback: use app.__module__ (may be "pynenc.app" in tests)
+        if app.__module__ != "__main__":
+            module = sys.modules.get(app.__module__)
+            if module and hasattr(module, "__file__"):
+                var_name = _find_app_variable_in_module(module, app)
+                return app.__module__, module.__file__, var_name
     except Exception:
         pass
 
-    return module_filepath, app_variable
+    return None, None, None
 
 
 def _import_app_from_module(app_info: AppInfo) -> Pynenc | None:

--- a/pynenc/util/import_app.py
+++ b/pynenc/util/import_app.py
@@ -317,7 +317,16 @@ def _find_pynenc_by_id_in_module(
             continue
         try:
             attr = getattr(module, attr_name)
-        except (AttributeError, TypeError):
+        except (AttributeError, TypeError, ImportError):
+            continue
+        except Exception as e:
+            logger.debug(
+                "Unexpected %s accessing %s.%s — skipping",
+                type(e).__name__,
+                mod_name,
+                attr_name,
+                exc_info=True,
+            )
             continue
         if isinstance(attr, Pynenc) and attr.app_id == app_id:
             logger.info("Found app %s in module %s", app_id, mod_name)
@@ -340,5 +349,14 @@ def create_app_from_info(app_info: AppInfo) -> Pynenc | None:
     if app := _import_app_from_module(app_info):
         return app
     if app_info.module != "__main__":
-        return _scan_loaded_modules(app_info.app_id)
+        try:
+            return _scan_loaded_modules(app_info.app_id)
+        except (ImportError, AttributeError, TypeError):
+            logger.debug("Module scan failed for %s", app_info.app_id, exc_info=True)
+        except Exception:
+            logger.warning(
+                "Unexpected error scanning modules for %s",
+                app_info.app_id,
+                exc_info=True,
+            )
     return None

--- a/pynenc_tests/unit/pynmon/views/test_starlette_compat.py
+++ b/pynenc_tests/unit/pynmon/views/test_starlette_compat.py
@@ -1,0 +1,90 @@
+"""
+Regression tests for Starlette 1.x TemplateResponse compatibility.
+
+Starlette 1.x removed the deprecated (name, context_dict) calling convention
+for TemplateResponse. Pynmon must use the request-first API:
+  TemplateResponse(request, name, context={...})
+which is supported by both Starlette 0.28+ and 1.x.
+
+These tests verify that pynmon views render without TypeError on any
+supported Starlette version.
+"""
+
+import pytest
+
+pytest.importorskip("fastapi", reason="pynmon tests require monitor dependencies")
+pytest.importorskip("jinja2", reason="pynmon tests require monitor dependencies")
+
+# All imports below must come after pytest.importorskip calls
+# ruff: noqa: E402
+import warnings
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from pynmon.app import app as pynmon_app, setup_routes
+
+setup_routes()
+
+if TYPE_CHECKING:
+    from pynenc import Pynenc
+
+
+def test_home_route_returns_200_no_unhashable_dict(
+    app_instance: "Pynenc",
+) -> None:
+    """GET / returns 200 without TypeError: unhashable type: dict."""
+    with patch("pynmon.views.home.get_active_app", return_value=app_instance):
+        with patch(
+            "pynmon.views.home.get_all_apps",
+            return_value={app_instance.app_id: app_instance},
+        ):
+            client = TestClient(pynmon_app, raise_server_exceptions=True)
+            response = client.get("/")
+
+            assert response.status_code == 200
+            assert "text/html" in response.headers["content-type"]
+
+
+def test_home_page_renders_expected_html_content(
+    app_instance: "Pynenc",
+) -> None:
+    """Home page renders HTML with expected dashboard title and app info."""
+    with patch("pynmon.views.home.get_active_app", return_value=app_instance):
+        with patch(
+            "pynmon.views.home.get_all_apps",
+            return_value={app_instance.app_id: app_instance},
+        ):
+            client = TestClient(pynmon_app, raise_server_exceptions=True)
+            response = client.get("/")
+
+            content = response.text
+            assert "<html" in content
+            assert app_instance.app_id in content
+
+
+def test_template_response_uses_request_first_api(
+    app_instance: "Pynenc",
+) -> None:
+    """Verify no Starlette DeprecationWarning for old-style TemplateResponse."""
+    with patch("pynmon.views.home.get_active_app", return_value=app_instance):
+        with patch(
+            "pynmon.views.home.get_all_apps",
+            return_value={app_instance.app_id: app_instance},
+        ):
+            client = TestClient(pynmon_app, raise_server_exceptions=True)
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                response = client.get("/")
+
+            assert response.status_code == 200
+            starlette_deprecations = [
+                w
+                for w in caught
+                if issubclass(w.category, DeprecationWarning)
+                and "TemplateResponse" in str(w.message)
+            ]
+            assert starlette_deprecations == [], (
+                f"Old-style TemplateResponse detected: {starlette_deprecations}"
+            )

--- a/pynenc_tests/unit/util/test_extract_module_info.py
+++ b/pynenc_tests/unit/util/test_extract_module_info.py
@@ -1,0 +1,205 @@
+"""Tests for extract_module_info and _find_app_in_user_modules.
+
+Verifies that module discovery correctly identifies the user module
+where ``app = Pynenc()`` was written, rather than returning
+``pynenc.app`` (where the class is defined).
+"""
+
+import types
+
+import pytest
+
+from pynenc.app import Pynenc
+from pynenc.util import import_app
+
+
+# ---------------------------------------------------------------------------
+# _find_app_variable_in_module
+# ---------------------------------------------------------------------------
+
+
+def test_find_app_variable_should_return_name_when_app_exists() -> None:
+    """Identity match on a normal module attribute."""
+    app = Pynenc()
+    module = types.ModuleType("user_tasks")
+    module.my_app = app  # type: ignore[attr-defined]
+
+    result = import_app._find_app_variable_in_module(module, app)
+    assert result == "my_app"
+
+
+def test_find_app_variable_should_return_none_when_not_present() -> None:
+    """Module has no reference to the app."""
+    app = Pynenc()
+    module = types.ModuleType("empty_mod")
+
+    result = import_app._find_app_variable_in_module(module, app)
+    assert result is None
+
+
+def test_find_app_variable_should_skip_private_attrs() -> None:
+    """Private attributes (underscore-prefixed) must be ignored."""
+    app = Pynenc()
+    module = types.ModuleType("private_mod")
+    module._hidden = app  # type: ignore[attr-defined]
+
+    result = import_app._find_app_variable_in_module(module, app)
+    assert result is None
+
+
+def test_find_app_variable_should_survive_getattr_errors() -> None:
+    """Modules with descriptors that raise on access must not crash."""
+    app = Pynenc()
+    module = types.ModuleType("bad_mod")
+
+    class _Bomb:
+        def __get__(self, obj: object, objtype: type | None = None) -> None:
+            raise RuntimeError("boom")
+
+    module.exploding = _Bomb()  # type: ignore[attr-defined]
+    module.safe_app = app  # type: ignore[attr-defined]
+
+    result = import_app._find_app_variable_in_module(module, app)
+    assert result == "safe_app"
+
+
+def test_find_app_variable_should_survive_dir_raising_import_error() -> None:
+    """If dir() on the module raises ImportError, return None gracefully."""
+    app = Pynenc()
+    module = types.ModuleType("broken_dir")
+
+    def bad_dir() -> list[str]:
+        raise ImportError("broken")
+
+    module.__dir__ = bad_dir  # type: ignore[method-assign]
+
+    result = import_app._find_app_variable_in_module(module, app)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _find_app_in_user_modules
+# ---------------------------------------------------------------------------
+
+
+def test_find_app_in_user_modules_should_find_registered_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When a user module is in sys.modules, it should be found."""
+    app = Pynenc()
+    fake_mod = types.ModuleType("my_project.tasks")
+    fake_mod.__file__ = "/home/user/project/tasks.py"
+    fake_mod.app = app  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(import_app.sys.modules, "my_project.tasks", fake_mod)
+
+    result = import_app._find_app_in_user_modules(app)
+    assert result is not None
+    mod_name, filepath, var_name = result
+    assert mod_name == "my_project.tasks"
+    assert filepath == "/home/user/project/tasks.py"
+    assert var_name == "app"
+
+
+def test_find_app_in_user_modules_should_skip_pynenc_internals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Modules under pynenc.* must be skipped even if they hold the app."""
+    app = Pynenc()
+    # pynenc.app always has the class, not the instance, but simulate it
+    fake_mod = types.ModuleType("pynenc.fake")
+    fake_mod.__file__ = "/path/to/pynenc/fake.py"
+    fake_mod.app = app  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(import_app.sys.modules, "pynenc.fake", fake_mod)
+
+    result = import_app._find_app_in_user_modules(app)
+    # Should not find it in pynenc.* — would fall through to None
+    # (unless some other module also has it, which we don't control in test)
+    if result is not None:
+        mod_name, _, _ = result
+        assert not mod_name.startswith("pynenc.")
+
+
+def test_find_app_in_user_modules_should_skip_modules_without_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Built-in modules (no __file__) must be skipped."""
+    app = Pynenc()
+    fake_mod = types.ModuleType("builtin_like")
+    # No __file__ attribute set
+    fake_mod.app = app  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(import_app.sys.modules, "builtin_like", fake_mod)
+
+    result = import_app._find_app_in_user_modules(app)
+    if result is not None:
+        mod_name, _, _ = result
+        assert mod_name != "builtin_like"
+
+
+# ---------------------------------------------------------------------------
+# extract_module_info
+# ---------------------------------------------------------------------------
+
+
+def test_extract_module_info_should_return_three_tuple(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Return value is a 3-tuple (module_name, filepath, variable)."""
+    app = Pynenc()
+    fake_mod = types.ModuleType("my_tasks")
+    fake_mod.__file__ = "/project/my_tasks.py"
+    fake_mod.application = app  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(import_app.sys.modules, "my_tasks", fake_mod)
+
+    result = import_app.extract_module_info(app)
+    assert len(result) == 3
+    mod_name, filepath, var_name = result
+    assert mod_name == "my_tasks"
+    assert filepath == "/project/my_tasks.py"
+    assert var_name == "application"
+
+
+def test_extract_module_info_should_prefer_user_module_over_pynenc_app(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """User module must be preferred over pynenc.app (the class definition module)."""
+    app = Pynenc()
+    user_mod = types.ModuleType("user_tasks")
+    user_mod.__file__ = "/home/user/tasks.py"
+    user_mod.app = app  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(import_app.sys.modules, "user_tasks", user_mod)
+
+    mod_name, filepath, var_name = import_app.extract_module_info(app)
+    assert mod_name == "user_tasks"
+    assert filepath == "/home/user/tasks.py"
+    assert var_name == "app"
+
+
+def test_extract_module_info_should_fallback_when_no_user_module() -> None:
+    """When no user module holds the app, fall back to app.__module__."""
+    app = Pynenc()
+    # Don't register any user module — only pynenc.app exists in sys.modules
+    mod_name, filepath, var_name = import_app.extract_module_info(app)
+    # Fallback returns pynenc.app info (the class definition module)
+    assert mod_name == "pynenc.app"
+    assert filepath is not None
+    assert filepath.endswith("app.py")
+
+
+def test_extract_module_info_should_return_nones_for_main_module() -> None:
+    """If app.__module__ is __main__ and no user module found, return Nones."""
+    app = Pynenc()
+    # Temporarily set __module__ to __main__
+    original = type(app).__module__
+    try:
+        type(app).__module__ = "__main__"
+        # No user module registered either
+        mod_name, filepath, var_name = import_app.extract_module_info(app)
+        # Should still find via fallback or return Nones
+        # Since the class __module__ is __main__, fallback won't trigger
+    finally:
+        type(app).__module__ = original

--- a/pynenc_tests/unit/util/test_scan_modules_resilience.py
+++ b/pynenc_tests/unit/util/test_scan_modules_resilience.py
@@ -1,0 +1,146 @@
+"""Tests for _find_pynenc_by_id_in_module and create_app_from_info resilience.
+
+Verifies that scanning arbitrary modules for Pynenc instances handles
+exceptions from lazy-loading modules (e.g. ``six.moves`` triggering
+``ModuleNotFoundError``) without crashing.
+"""
+
+import logging
+import types
+from unittest.mock import patch
+
+import pytest
+
+from pynenc.app import Pynenc
+from pynenc.app_info import AppInfo
+from pynenc.util import import_app
+
+
+# ---------------------------------------------------------------------------
+# _find_pynenc_by_id_in_module — getattr raises arbitrary exceptions
+# ---------------------------------------------------------------------------
+
+
+def test_getattr_raising_import_error_is_skipped() -> None:
+    """ModuleNotFoundError from lazy __getattr__ must not crash the scan."""
+    module = types.ModuleType("lazy_mod")
+
+    class _LazyDescriptor:
+        def __get__(self, obj: object, objtype: type | None = None) -> None:
+            raise ModuleNotFoundError("No module named '_gdbm'")
+
+    module.dbm_gnu = _LazyDescriptor()  # type: ignore[attr-defined]
+
+    result = import_app._find_pynenc_by_id_in_module(module, "lazy_mod", "any_id")
+    assert result is None
+
+
+def test_getattr_raising_runtime_error_is_skipped() -> None:
+    """RuntimeError from exotic __getattr__ must not crash the scan."""
+    module = types.ModuleType("weird_mod")
+
+    class _Boom:
+        def __get__(self, obj: object, objtype: type | None = None) -> None:
+            raise RuntimeError("descriptor chaos")
+
+    module.chaos = _Boom()  # type: ignore[attr-defined]
+
+    result = import_app._find_pynenc_by_id_in_module(module, "weird_mod", "any_id")
+    assert result is None
+
+
+def test_finds_matching_app_id() -> None:
+    """Normal case: module has a Pynenc instance with matching app_id."""
+    app = Pynenc()
+    module = types.ModuleType("good_mod")
+    module.app = app  # type: ignore[attr-defined]
+
+    result = import_app._find_pynenc_by_id_in_module(module, "good_mod", app.app_id)
+    assert result is app
+
+
+def test_skips_non_matching_app_id() -> None:
+    """Returns None when app_id doesn't match."""
+    app = Pynenc()
+    module = types.ModuleType("good_mod")
+    module.app = app  # type: ignore[attr-defined]
+
+    result = import_app._find_pynenc_by_id_in_module(
+        module, "good_mod", "nonexistent_id"
+    )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# create_app_from_info — _scan_loaded_modules failure must not prevent fallback
+# ---------------------------------------------------------------------------
+
+
+def test_create_app_from_info_returns_none_when_scan_raises() -> None:
+    """If _scan_loaded_modules raises ImportError, create_app_from_info returns None
+    so that Pynenc.from_info's config-based fallback can execute."""
+    app_info = AppInfo(
+        app_id="test_app",
+        module="some.module",
+        module_filepath=None,
+        app_variable=None,
+    )
+
+    with (
+        patch.object(import_app, "_import_app_from_module", return_value=None),
+        patch.object(
+            import_app,
+            "_scan_loaded_modules",
+            side_effect=ModuleNotFoundError("_gdbm"),
+        ),
+    ):
+        result = import_app.create_app_from_info(app_info)
+
+    assert result is None
+
+
+def test_create_app_from_info_logs_warning_on_unexpected_error(
+    caplog: "pytest.LogCaptureFixture",
+) -> None:
+    """Unexpected exceptions from _scan_loaded_modules are logged at WARNING
+    so they surface for debugging, but don't crash the caller."""
+    app_info = AppInfo(
+        app_id="test_app",
+        module="some.module",
+        module_filepath=None,
+        app_variable=None,
+    )
+
+    with (
+        patch.object(import_app, "_import_app_from_module", return_value=None),
+        patch.object(
+            import_app,
+            "_scan_loaded_modules",
+            side_effect=RuntimeError("totally unexpected"),
+        ),
+        caplog.at_level(logging.WARNING, logger="pynenc.util.import_app"),
+    ):
+        result = import_app.create_app_from_info(app_info)
+
+    assert result is None
+    assert "Unexpected error scanning modules" in caplog.text
+    assert "test_app" in caplog.text
+
+
+def test_create_app_from_info_succeeds_via_scan() -> None:
+    """Normal path: _scan_loaded_modules finds the app."""
+    app = Pynenc()
+    app_info = AppInfo(
+        app_id=app.app_id,
+        module="some.module",
+        module_filepath=None,
+        app_variable=None,
+    )
+
+    with (
+        patch.object(import_app, "_import_app_from_module", return_value=None),
+        patch.object(import_app, "_scan_loaded_modules", return_value=app),
+    ):
+        result = import_app.create_app_from_info(app_info)
+
+    assert result is app

--- a/pynmon/app.py
+++ b/pynmon/app.py
@@ -384,7 +384,8 @@ def hydrate_app_instances(
             else:
                 logger.warning(f"Failed to hydrate app: {app_id}")
         except Exception as e:
-            logger.error(f"Error hydrating app {app_id}: {e}", exc_info=True)
+            logger.warning("Could not hydrate app %s: %s", app_id, e)
+            logger.debug("Hydration traceback for %s:", app_id, exc_info=True)
 
     return instances
 

--- a/pynmon/util/view_helpers.py
+++ b/pynmon/util/view_helpers.py
@@ -37,12 +37,9 @@ def render_error_response(
     :return: HTMLResponse with error template
     """
     return templates.TemplateResponse(
+        request,
         "shared/error.html",
-        {
-            "request": request,
-            "title": title,
-            "message": message,
-        },
+        context={"title": title, "message": message},
         status_code=status_code,
     )
 

--- a/pynmon/views/broker.py
+++ b/pynmon/views/broker.py
@@ -20,9 +20,9 @@ async def broker_view(request: Request) -> HTMLResponse:
     }
 
     return templates.TemplateResponse(
+        request,
         "broker/overview.html",
-        {
-            "request": request,
+        context={
             "title": "Broker Monitor",
             "app_id": app.app_id,
             "broker_info": broker_info,
@@ -52,9 +52,9 @@ async def queue_view(
         app.broker.route_invocation(invocation.invocation_id)
 
     return templates.TemplateResponse(
+        request,
         "broker/queue.html",
-        {
-            "request": request,
+        context={
             "title": "Broker Queue",
             "app_id": app.app_id,
             "pending_invocations": pending_invocations,
@@ -72,13 +72,13 @@ async def refresh_broker(request: Request) -> HTMLResponse:
     pending_count = app.broker.count_invocations()
 
     return templates.TemplateResponse(
+        request,
         "broker/partials/info.html",
-        {
-            "request": request,
+        context={
             "broker_info": {
                 "type": app.broker.__class__.__name__,
                 "pending_count": pending_count,
-            },
+            }
         },
     )
 

--- a/pynmon/views/calls.py
+++ b/pynmon/views/calls.py
@@ -192,7 +192,7 @@ async def process_call_detail(
         logger.info(
             f"Rendering call detail template with {len(invocations)} invocations"
         )
-        return templates.TemplateResponse("calls/detail.html", context)
+        return templates.TemplateResponse(request, "calls/detail.html", context=context)
 
     except Exception as e:
         logger.exception(
@@ -220,7 +220,6 @@ def _create_call_detail_context(
     formatted_args, raw_args = format_serialized_arguments(serialized)
 
     return {
-        "request": request,
         "app_id": app.app_id,
         "call": target_call,
         "task": target_task,
@@ -262,9 +261,9 @@ async def call_detail_by_query(request: Request) -> HTMLResponse:
     except Exception as e:
         logger.exception(f"Unhandled exception in call_detail_by_query: {str(e)}")
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
+            context={
                 "title": "Unexpected Error",
                 "message": f"An unexpected error occurred: {str(e)}",
             },

--- a/pynmon/views/client_data_store.py
+++ b/pynmon/views/client_data_store.py
@@ -34,9 +34,9 @@ async def client_data_view(request: Request) -> HTMLResponse:
             f"Rendering client data store template in {time.time() - start_time:.2f}s"
         )
         return templates.TemplateResponse(
+            request,
             "client_data_store/overview.html",
-            {
-                "request": request,
+            context={
                 "title": "Client Data Store Monitor",
                 "app_id": app.app_id,
                 "client_data_store_info": client_data_store_info,
@@ -45,9 +45,9 @@ async def client_data_view(request: Request) -> HTMLResponse:
     except Exception as e:
         logger.exception(f"Error in client_data_view: {str(e)}")
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
+            context={
                 "title": "Error",
                 "message": f"An error occurred in the client data store view: {str(e)}",
             },

--- a/pynmon/views/family_tree.py
+++ b/pynmon/views/family_tree.py
@@ -75,9 +75,9 @@ async def invocation_family_tree(
     svg_content = await asyncio.to_thread(_build_svg, invocation_id, expand_ids)
     template = "partials/family_tree_bare.html" if bare else "partials/family_tree.html"
     return templates.TemplateResponse(
+        request,
         template,
-        {
-            "request": request,
+        context={
             "family_tree_svg": svg_content,
         },
     )

--- a/pynmon/views/home.py
+++ b/pynmon/views/home.py
@@ -132,9 +132,9 @@ async def index(request: Request) -> HTMLResponse:
 
     if not all_apps or not active_app:
         return templates.TemplateResponse(
+            request,
             "critical_error.html",
-            {
-                "request": request,
+            context={
                 "title": "No App Configured",
                 "message": "No Pynenc application is configured for monitoring.",
             },
@@ -156,9 +156,9 @@ async def index(request: Request) -> HTMLResponse:
     registered_tasks = len(active_app.tasks)
 
     return templates.TemplateResponse(
+        request,
         "index.html",
-        {
-            "request": request,
+        context={
             "app_id": active_app.app_id,
             "all_apps": list(all_apps.keys()),
             "components": components,

--- a/pynmon/views/invocations.py
+++ b/pynmon/views/invocations.py
@@ -128,9 +128,9 @@ async def invocations_list(
     )
 
     return templates.TemplateResponse(
+        request,
         "invocations/list.html",
-        {
-            "request": request,
+        context={
             "title": "Invocations Monitor",
             "app_id": app.app_id,
             "invocations": all_invocations,
@@ -423,9 +423,9 @@ async def invocations_timeline(
         )
 
         return templates.TemplateResponse(
+            request,
             "invocations/timeline.html",
-            {
-                "request": request,
+            context={
                 "title": "Invocations Timeline",
                 "app_id": app.app_id,
                 "svg_content": svg_content,
@@ -449,9 +449,9 @@ async def invocations_timeline(
     except Exception as e:
         logger.exception(f"Error in invocations_timeline: {str(e)}")
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
+            context={
                 "title": "Error",
                 "message": f"An error occurred while generating the timeline: {str(e)}",
             },
@@ -662,9 +662,9 @@ async def invocation_detail(
             f"Rendering invocation detail template in {time.time() - start_time:.2f}s"
         )
         return templates.TemplateResponse(
+            request,
             "invocations/detail.html",
-            {
-                "request": request,
+            context={
                 "title": "Invocation Details",
                 "app_id": app.app_id,
                 "invocation": invocation,
@@ -685,9 +685,9 @@ async def invocation_detail(
     except InvocationNotFoundError:
         logger.warning(f"No invocation found with ID: {invocation_id}")
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
+            context={
                 "title": "Invocation Not Found",
                 "message": f"No invocation found with ID: {invocation_id}",
             },
@@ -696,12 +696,9 @@ async def invocation_detail(
     except Exception as e:
         logger.exception(f"Unexpected error in invocation_detail: {str(e)}")
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
-                "title": "Error",
-                "message": f"An error occurred: {str(e)}",
-            },
+            context={"title": "Error", "message": f"An error occurred: {str(e)}"},
             status_code=500,
         )
     finally:
@@ -913,9 +910,7 @@ async def invocations_table(
     all_invocations = await asyncio.to_thread(_fetch_table_invocations)
 
     return templates.TemplateResponse(
+        request,
         "invocations/partials/table.html",
-        {
-            "request": request,
-            "invocations": all_invocations,
-        },
+        context={"invocations": all_invocations},
     )

--- a/pynmon/views/log_explorer.py
+++ b/pynmon/views/log_explorer.py
@@ -116,9 +116,9 @@ async def log_explorer(
     app = get_pynenc_instance()
     analysis = await _analyse_logs(app, log) if log.strip() else None
     return templates.TemplateResponse(
+        request,
         "log_explorer/index.html",
-        {
-            "request": request,
+        context={
             "title": "Log Explorer",
             "app_id": app.app_id,
             "log": log,

--- a/pynmon/views/orchestrator.py
+++ b/pynmon/views/orchestrator.py
@@ -72,9 +72,9 @@ async def orchestrator_view(request: Request) -> HTMLResponse:
     active_runners = await asyncio.to_thread(app.orchestrator.get_active_runners)
 
     return templates.TemplateResponse(
+        request,
         "orchestrator/overview.html",
-        {
-            "request": request,
+        context={
             "title": "Orchestrator Monitor",
             "app_id": app.app_id,
             "orchestrator_info": orchestrator_info,
@@ -99,9 +99,9 @@ async def refresh_orchestrator(request: Request) -> HTMLResponse:
     )
 
     return templates.TemplateResponse(
+        request,
         "orchestrator/partials/stats.html",
-        {
-            "request": request,
+        context={
             "status_counts": status_counts,
             "blocking_invocations": blocking_invocations,
         },

--- a/pynmon/views/runner.py
+++ b/pynmon/views/runner.py
@@ -36,12 +36,9 @@ async def runners_index(request: Request) -> HTMLResponse:
         runners_info["error"] = str(e)
 
     return templates.TemplateResponse(
+        request,
         "runners.html",
-        {
-            "request": request,
-            "runners_info": runners_info,
-            "app_id": pynenc.app_id,
-        },
+        context={"runners_info": runners_info, "app_id": pynenc.app_id},
     )
 
 
@@ -58,13 +55,15 @@ async def refresh_runners(request: Request) -> HTMLResponse:
             runners = await pynenc.broker.get_runners()
         else:
             return templates.TemplateResponse(
+                request,
                 "components/not_implemented.html",
-                {"request": request, "feature": "Runner listing"},
+                context={"feature": "Runner listing"},
             )
     except Exception as e:
         error = str(e)
 
     return templates.TemplateResponse(
+        request,
         "components/runner_list.html",
-        {"request": request, "runners": runners, "error": error},
+        context={"runners": runners, "error": error},
     )

--- a/pynmon/views/runners.py
+++ b/pynmon/views/runners.py
@@ -126,9 +126,9 @@ async def runners_view(request: Request) -> HTMLResponse:
     runner_config = _collect_runner_config(app)
 
     return templates.TemplateResponse(
+        request,
         "runners/overview.html",
-        {
-            "request": request,
+        context={
             "title": "Active Runners",
             "app_id": app.app_id,
             "enriched_runners": enriched_runners,
@@ -157,11 +157,9 @@ async def refresh_runners(request: Request) -> HTMLResponse:
     ]
 
     return templates.TemplateResponse(
+        request,
         "runners/partials/runners_table.html",
-        {
-            "request": request,
-            "enriched_runners": enriched_runners,
-        },
+        context={"enriched_runners": enriched_runners},
     )
 
 
@@ -194,9 +192,9 @@ async def runner_detail(request: Request, runner_id: str) -> HTMLResponse:
         }
 
     return templates.TemplateResponse(
+        request,
         "runners/detail.html",
-        {
-            "request": request,
+        context={
             "title": f"Runner {runner_id[:8]}",
             "app_id": app.app_id,
             "runner_info": runner_info,
@@ -240,9 +238,9 @@ async def atomic_service_timeline(request: Request) -> HTMLResponse:
             )
 
     return templates.TemplateResponse(
+        request,
         "runners/atomic_service_timeline.html",
-        {
-            "request": request,
+        context={
             "title": "Atomic Service Timeline",
             "app_id": app.app_id,
             "timeline_data": timeline_data,

--- a/pynmon/views/state_backend.py
+++ b/pynmon/views/state_backend.py
@@ -35,9 +35,9 @@ async def state_backend_view(request: Request) -> HTMLResponse:
             f"Rendering state backend template in {time.time() - start_time:.2f}s"
         )
         return templates.TemplateResponse(
+            request,
             "state_backend/overview.html",
-            {
-                "request": request,
+            context={
                 "title": "State Backend Monitor",
                 "app_id": app.app_id,
                 "state_backend_info": state_backend_info,
@@ -47,9 +47,9 @@ async def state_backend_view(request: Request) -> HTMLResponse:
     except Exception as e:
         logger.exception(f"Error in state_backend_view: {str(e)}")
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
+            context={
                 "title": "Error",
                 "message": f"An error occurred in the state backend view: {str(e)}",
             },

--- a/pynmon/views/tasks.py
+++ b/pynmon/views/tasks.py
@@ -70,13 +70,9 @@ async def tasks_list(request: Request) -> HTMLResponse:
     logger.info(f"Found {len(tasks)} tasks")
 
     return templates.TemplateResponse(
+        request,
         "tasks/list.html",
-        {
-            "request": request,
-            "title": "Tasks Monitor",
-            "app_id": app.app_id,
-            "tasks": tasks,
-        },
+        context={"title": "Tasks Monitor", "app_id": app.app_id, "tasks": tasks},
     )
 
 
@@ -91,11 +87,9 @@ async def refresh_tasks_list(request: Request) -> HTMLResponse:
     logger.info(f"Found {len(tasks)} tasks")
 
     return templates.TemplateResponse(
+        request,
         "tasks/partials/list_content.html",
-        {
-            "request": request,
-            "tasks": tasks,
-        },
+        context={"tasks": tasks},
     )
 
 
@@ -104,9 +98,9 @@ async def task_detail(request: Request, task_id_key: str) -> HTMLResponse:
     """Display detailed information about a specific task."""
     if not task_id_key:
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
+            context={
                 "title": "Missing Task ID",
                 "message": "No task_id was provided. Please check the URL and try again.",
             },
@@ -118,9 +112,9 @@ async def task_detail(request: Request, task_id_key: str) -> HTMLResponse:
     except ValueError as e:
         logger.warning(f"Invalid task ID format: {task_id_key} - {str(e)}")
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
+            context={
                 "title": "Invalid Task ID Format",
                 "message": f"The provided task ID is not properly formatted: {str(e)}",
             },
@@ -141,9 +135,9 @@ async def task_detail(request: Request, task_id_key: str) -> HTMLResponse:
                 f"No task found with ID: {task_id} - {type(e).__name__}: {e}"
             )
             return templates.TemplateResponse(
+                request,
                 "shared/error.html",
-                {
-                    "request": request,
+                context={
                     "title": "Task Not Found",
                     "message": f"No task found with ID: {task_id}",
                 },
@@ -153,9 +147,9 @@ async def task_detail(request: Request, task_id_key: str) -> HTMLResponse:
         if not task:
             logger.warning(f"No task found with ID: {task_id}")
             return templates.TemplateResponse(
+                request,
                 "shared/error.html",
-                {
-                    "request": request,
+                context={
                     "title": "Task Not Found",
                     "message": f"No task found with ID: {task_id}",
                 },
@@ -171,9 +165,9 @@ async def task_detail(request: Request, task_id_key: str) -> HTMLResponse:
 
         logger.info(f"Rendering template with {len(calls)} calls")
         return templates.TemplateResponse(
+            request,
             "tasks/detail.html",
-            {
-                "request": request,
+            context={
                 "title": "Task Details",
                 "app_id": app.app_id,
                 "task": task,
@@ -184,12 +178,9 @@ async def task_detail(request: Request, task_id_key: str) -> HTMLResponse:
     except Exception as e:
         logger.exception(f"Unexpected error in task_detail: {str(e)}")
         return templates.TemplateResponse(
+            request,
             "shared/error.html",
-            {
-                "request": request,
-                "title": "Error",
-                "message": f"An error occurred: {str(e)}",
-            },
+            context={"title": "Error", "message": f"An error occurred: {str(e)}"},
             status_code=500,
         )
     finally:

--- a/pynmon/views/workflows.py
+++ b/pynmon/views/workflows.py
@@ -51,9 +51,9 @@ async def workflows_list(request: Request) -> HTMLResponse:
         workflows_with_runs = []
 
     return templates.TemplateResponse(
+        request,
         "workflows/list.html",
-        {
-            "request": request,
+        context={
             "title": "Workflows Monitor",
             "app_id": app.app_id,
             "workflows": workflows_with_runs,
@@ -91,11 +91,9 @@ async def refresh_workflows_list(request: Request) -> HTMLResponse:
         workflows_with_runs = []
 
     return templates.TemplateResponse(
+        request,
         "workflows/partials/list_content.html",
-        {
-            "request": request,
-            "workflows": workflows_with_runs,
-        },
+        context={"workflows": workflows_with_runs},
     )
 
 
@@ -120,9 +118,9 @@ async def workflow_runs_list(request: Request) -> HTMLResponse:
         sorted_runs = []
 
     return templates.TemplateResponse(
+        request,
         "workflows/runs.html",
-        {
-            "request": request,
+        context={
             "title": "Workflow Runs",
             "app_id": app.app_id,
             "workflow_runs": sorted_runs,
@@ -151,11 +149,9 @@ async def refresh_workflow_runs_list(request: Request) -> HTMLResponse:
         sorted_runs = []
 
     return templates.TemplateResponse(
+        request,
         "workflows/partials/runs_content.html",
-        {
-            "request": request,
-            "workflow_runs": sorted_runs,
-        },
+        context={"workflow_runs": sorted_runs},
     )
 
 
@@ -186,9 +182,9 @@ async def workflow_detail(request: Request, workflow_type_key: str) -> HTMLRespo
         task_extra = format_task_extra_info(task) if task else None
 
         return templates.TemplateResponse(
+            request,
             "workflows/detail.html",
-            {
-                "request": request,
+            context={
                 "title": "Workflow Details",
                 "app_id": app.app_id,
                 "workflow_type": workflow_type,
@@ -204,9 +200,9 @@ async def workflow_detail(request: Request, workflow_type_key: str) -> HTMLRespo
         )
 
         return templates.TemplateResponse(
+            request,
             "error.html",
-            {
-                "request": request,
+            context={
                 "title": "Error",
                 "app_id": app.app_id,
                 "error_title": "Workflow Not Found",
@@ -243,9 +239,9 @@ async def refresh_workflow_detail(
         task_extra = format_task_extra_info(task) if task else None
 
         return templates.TemplateResponse(
+            request,
             "workflows/partials/detail_content.html",
-            {
-                "request": request,
+            context={
                 "workflow_type": workflow_type,
                 "workflow_runs": sorted_runs,
                 "task": task,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,10 @@ pynenc = "pynenc.__main__:main"
 
 [dependency-groups]
 dev = [
-    "black==23.11.0",
+    "black==26.3.1",
 ]
 docs = [
-    "sphinx>=8.0,<9",
+    "sphinx>=8.0,<10",
     "myst-parser>=4.0",
     "furo>=2024",
     "sphinx-copybutton>=0.5.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pynenc"
-version = "0.2.0"
+version = "0.2.1"
 description = "A task management system for complex distributed orchestration"
 authors = [{ name = "Luis Diaz", email = "code.luis.diaz@proton.me" }]
 license = { text = "MIT License" }

--- a/uv.lock
+++ b/uv.lock
@@ -79,7 +79,7 @@ wheels = [
 
 [[package]]
 name = "black"
-version = "23.11.0"
+version = "26.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -87,10 +87,26 @@ dependencies = [
     { name = "packaging" },
     { name = "pathspec" },
     { name = "platformdirs" },
+    { name = "pytokens" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/21/c2d38c7c98a089fd0f7e1a8be16c07f141ed57339b3082737de90db0ca59/black-23.11.0.tar.gz", hash = "sha256:4c68855825ff432d197229846f971bc4d6666ce90492e5b02013bcaca4d9ab05", size = 615416, upload-time = "2023-11-08T05:41:30.844Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/fb/8a670d2a246a351d7662e785d85a636c1c60b5800d175421cdfcb2a59b1d/black-23.11.0-py3-none-any.whl", hash = "sha256:54caaa703227c6e0c87b76326d0862184729a69b73d3b7305b6288e1d830067e", size = 191996, upload-time = "2023-11-08T05:41:28.288Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f8/da5eae4fc75e78e6dceb60624e1b9662ab00d6b452996046dfa9b8a6025b/black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1", size = 1895920, upload-time = "2026-03-12T03:40:13.921Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9f/04e6f26534da2e1629b2b48255c264cabf5eedc5141d04516d9d68a24111/black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f", size = 1718499, upload-time = "2026-03-12T03:40:15.239Z" },
+    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7", size = 1794994, upload-time = "2026-03-12T03:40:17.124Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/0a/86e462cdd311a3c2a8ece708d22aba17d0b2a0d5348ca34b40cdcbea512e/black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983", size = 1420867, upload-time = "2026-03-12T03:40:18.83Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e5/22515a19cb7eaee3440325a6b0d95d2c0e88dd180cb011b12ae488e031d1/black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb", size = 1230124, upload-time = "2026-03-12T03:40:20.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/77/5728052a3c0450c53d9bb3945c4c46b91baa62b2cafab6801411b6271e45/black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54", size = 1895034, upload-time = "2026-03-12T03:40:21.813Z" },
+    { url = "https://files.pythonhosted.org/packages/52/73/7cae55fdfdfbe9d19e9a8d25d145018965fe2079fa908101c3733b0c55a0/black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f", size = 1718503, upload-time = "2026-03-12T03:40:23.666Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56", size = 1793557, upload-time = "2026-03-12T03:40:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/43/10/d6c06a791d8124b843bf325ab4ac7d2f5b98731dff84d6064eafd687ded1/black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839", size = 1422766, upload-time = "2026-03-12T03:40:27.14Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4f/40a582c015f2d841ac24fed6390bd68f0fc896069ff3a886317959c9daf8/black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2", size = 1232140, upload-time = "2026-03-12T03:40:28.882Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/e36e27c9cebc1311b7579210df6f1c86e50f2d7143ae4fcf8a5017dc8809/black-26.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78", size = 1889234, upload-time = "2026-03-12T03:40:30.964Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7b/9871acf393f64a5fa33668c19350ca87177b181f44bb3d0c33b2d534f22c/black-26.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568", size = 1720522, upload-time = "2026-03-12T03:40:32.346Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/e766c7f2e90c07fb7586cc787c9ae6462b1eedab390191f2b7fc7f6170a9/black-26.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f", size = 1787824, upload-time = "2026-03-12T03:40:33.636Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/94/2424338fb2d1875e9e83eed4c8e9c67f6905ec25afd826a911aea2b02535/black-26.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c", size = 1445855, upload-time = "2026-03-12T03:40:35.442Z" },
+    { url = "https://files.pythonhosted.org/packages/86/43/0c3338bd928afb8ee7471f1a4eec3bdbe2245ccb4a646092a222e8669840/black-26.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1", size = 1258109, upload-time = "2026-03-12T03:40:36.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
 ]
 
 [[package]]
@@ -613,11 +629,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "0.12.1"
+version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]
@@ -834,11 +850,11 @@ requires-dist = [
 provides-extras = ["monitor", "tests"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "black", specifier = "==23.11.0" }]
+dev = [{ name = "black", specifier = "==26.3.1" }]
 docs = [
     { name = "furo", specifier = ">=2024" },
     { name = "myst-parser", specifier = ">=4.0" },
-    { name = "sphinx", specifier = ">=8.0,<9" },
+    { name = "sphinx", specifier = ">=8.0,<10" },
     { name = "sphinx-autodoc2", specifier = ">=0.5.0" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-design", specifier = ">=0.6.0" },
@@ -932,6 +948,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
+    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -759,7 +759,7 @@ wheels = [
 
 [[package]]
 name = "pynenc"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "cistell" },


### PR DESCRIPTION
## Release v0.2.1

### Fixed
- **Fix pynmon Starlette 1.x template rendering crash**: migrated all `TemplateResponse` calls to the Starlette 1.x request-first API
- **Fix `pynenc monitor` crash during app hydration**: resilient exception handling in `import_app.py` module scanning

### Changed
- **CI: unlocked-deps test job**: catches transitive dependency breakage before downstream users do
- **Updated `uv.lock`**: FastAPI 0.136.0, Starlette 1.0.0

### Tests
- Starlette compat regression tests
- Module scan resilience tests