### PR TITLE
feat: invocation state machine renderer, CLI auto-discovery, v0.2.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,12 @@ repos:
       - id: mypy
         additional_dependencies:
           ["types-PyYAML", "types-requests", "types-setuptools"]
+
+  - repo: local
+    hooks:
+      - id: invocation-state-machine-svg
+        name: invocation state machine SVG is current
+        entry: uv run pynenc status render --format svg --check
+        language: system
+        pass_filenames: false
+        files: ^(pynenc/invocation/status\.py|pynenc/invocation/status_graph\.py|pynenc/cli/status_cli\.py|docs/_static/invocation_state_machine\.svg)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,12 +41,3 @@ repos:
       - id: mypy
         additional_dependencies:
           ["types-PyYAML", "types-requests", "types-setuptools"]
-
-  - repo: local
-    hooks:
-      - id: invocation-state-machine-svg
-        name: invocation state machine SVG is current
-        entry: uv run pynenc status render --format svg --check
-        language: system
-        pass_filenames: false
-        files: ^(pynenc/invocation/status\.py|pynenc/invocation/status_graph\.py|pynenc/cli/status_cli\.py|docs/_static/invocation_state_machine\.svg)$

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@
 
 Pynenc addresses the complex challenges of task management in distributed environments, offering a robust solution for developers looking to efficiently orchestrate asynchronous tasks across multiple systems. By combining intuitive configuration with advanced features like automatic task prioritization, Pynenc empowers developers to build scalable and reliable distributed applications with ease.
 
-## 🆕 What's New in v0.2.2
+## 🆕 What's New in v0.2.3
 
-- **Pynmon compatibility**: migrated `TemplateResponse` calls to the Starlette 1.x API, fixing crashes on all pynmon views
-- **Monitor stability**: broadened exception handling in app hydration so that lazy-loading modules no longer crash `pynenc monitor`
-- **Invocations tab fix**: `extract_module_info` now correctly resolves the user module instead of the pynenc core module
-- **Dependency bumps**: FastAPI 0.136.0, Starlette 1.0.0, black 26.3.1, sphinx &lt;10
+- **Invocation status state machine diagram**: `pynenc status render` generates a text or SVG view of the state machine directly from `pynenc.invocation.status`. The SVG is committed under `docs/_static/` and embedded in the README, the docs landing page, and the invocation status guide. A pre-commit hook keeps it aligned with the implementation
+- **CLI app auto-discovery**: when the current directory contains a single Python file with a `Pynenc()` instance, `pynenc runner start` and `pynenc monitor` no longer require `--app`. Use `--app` only when more than one app is available or when running from another directory
+- **Dropped `PENDING -> FAILED` transition**: cycle-control is deprecated and the status unnecessary
+- **Hardened multi-thread shutdown**: worker SIGTERM handlers ignore repeated signals so a second termination cannot re-enter shutdown logging
 
 See the [Changelog](https://docs.pynenc.org/changelog.html) for the complete list of changes.
 
@@ -90,6 +90,10 @@ See the [Changelog](https://docs.pynenc.org/changelog.html) for the complete lis
   - Automatic recovery of stuck PENDING and RUNNING invocations
   - Runner heartbeat monitoring to detect inactive runners
   - Comprehensive state transitions with validation
+
+  <p align="center">
+    <img src="docs/_static/invocation_state_machine.svg" alt="Pynenc invocation status state machine" width="100%">
+  </p>
 
 - **Configurable Concurrency Management**: Pynenc offers versatile concurrency control mechanisms at various levels:
 
@@ -246,10 +250,16 @@ To get started with Pynenc, here's a simple example that demonstrates the creati
      Start a runner in a separate terminal or script:
 
      ```bash
-     pynenc --app=tasks.app runner start
+     pynenc runner start
      ```
 
-     Check for the [basic_redis_example](https://github.com/pynenc/samples/tree/main/basic_redis_example) (requires `pynenc-redis` plugin)
+   The CLI auto-discovers the app when the current directory contains exactly one importable file with a `Pynenc()` instance. If your project has multiple apps, select one explicitly:
+
+   ```bash
+   pynenc --app tasks.app runner start
+   ```
+
+   Check for the [basic_redis_example](https://github.com/pynenc/samples/tree/main/basic_redis_example) (requires `pynenc-redis` plugin)
 
    - **Synchronously:**
      For test or local demonstration, to try synchronous execution, you can set the environment variable `PYNENC__DEV_MODE_FORCE_SYNC_TASKS=True` to force tasks to run in the same thread.
@@ -338,6 +348,12 @@ Paste your Pynenc log lines and the Log Explorer augments them with full context
 ### Starting the Monitor
 
 The monitor requires a Pynenc app defined in your codebase:
+
+```bash
+pynenc monitor --host 127.0.0.1 --port 8000
+```
+
+If more than one app is available, specify the one to inspect:
 
 ```bash
 pynenc --app your_app_module monitor --host 127.0.0.1 --port 8000

--- a/docs/_static/invocation_state_machine.svg
+++ b/docs/_static/invocation_state_machine.svg
@@ -1,0 +1,230 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="760" viewBox="0 0 1600 760" role="img" aria-labelledby="title desc">
+<title id="title">Pynenc invocation status state machine</title>
+<desc id="desc">Generated from pynenc.invocation.status. Shows allowed transitions, ownership, recovery, and final states.</desc>
+<rect width="1600" height="760" rx="18" fill="#fbf8f5"/>
+<text x="48" y="48" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="24" font-weight="700" fill="#2f221d">Invocation status state machine</text>
+<text x="48" y="74" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" fill="#735d52">Generated from pynenc.invocation.status</text>
+<defs>
+<filter id="shadow" x="-15%" y="-25%" width="130%" height="160%">
+<feDropShadow dx="0" dy="6" stdDeviation="5" flood-color="#3a241a" flood-opacity="0.13"/>
+</filter>
+<marker id="arrow-start" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+<path d="M0,0 L0,6 L8,3 z" fill="#b95a3d"/>
+</marker>
+<marker id="arrow-available" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+<path d="M0,0 L0,6 L8,3 z" fill="#39835a"/>
+</marker>
+<marker id="arrow-owned" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+<path d="M0,0 L0,6 L8,3 z" fill="#c66a2e"/>
+</marker>
+<marker id="arrow-recovery" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+<path d="M0,0 L0,6 L8,3 z" fill="#4f75c8"/>
+</marker>
+<marker id="arrow-concurrency" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+<path d="M0,0 L0,6 L8,3 z" fill="#c7506e"/>
+</marker>
+<marker id="arrow-final" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+<path d="M0,0 L0,6 L8,3 z" fill="#677084"/>
+</marker>
+</defs>
+<g data-edge="START->REGISTERED">
+<line x1="92.0" y1="300.0" x2="162.0" y2="300.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="92.0" y1="300.0" x2="162.0" y2="300.0" stroke="#39835a" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-available)" opacity="0.88"/>
+</g>
+<g data-edge="CONCURRENCY_CONTROLLED->REROUTED">
+<line x1="558.0" y1="115.0" x2="602.0" y2="115.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="558.0" y1="115.0" x2="602.0" y2="115.0" stroke="#39835a" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-available)" opacity="0.88"/>
+</g>
+<g data-edge="KILLED->REROUTED">
+<line x1="1072.0" y1="503.0" x2="778.0" y2="143.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="1072.0" y1="503.0" x2="778.0" y2="143.0" stroke="#39835a" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-available)" opacity="0.88"/>
+</g>
+<g data-edge="PAUSED->KILLED">
+<line x1="982.0" y1="154.0" x2="1202.0" y2="456.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="982.0" y1="154.0" x2="1202.0" y2="456.0" stroke="#b95a3d" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-start)" opacity="0.88"/>
+</g>
+<g data-edge="PAUSED->RESUMED">
+<line x1="1018.0" y1="115.0" x2="1072.0" y2="115.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="1018.0" y1="115.0" x2="1072.0" y2="115.0" stroke="#c66a2e" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-owned)" opacity="0.88"/>
+</g>
+<g data-edge="PENDING->KILLED">
+<line x1="524.0" y1="329.0" x2="1072.0" y2="503.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="524.0" y1="329.0" x2="1072.0" y2="503.0" stroke="#b95a3d" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-start)" opacity="0.88"/>
+</g>
+<g data-edge="PENDING->PENDING_RECOVERY">
+<line x1="428.0" y1="329.0" x2="428.0" y2="581.0" stroke="#fbf8f5" stroke-width="3.25" stroke-linecap="round" opacity="0.65"/>
+<line x1="428.0" y1="329.0" x2="428.0" y2="581.0" stroke="#4f75c8" stroke-width="1.85" stroke-linecap="round" marker-end="url(#arrow-recovery)" opacity="0.88"/>
+</g>
+<g data-edge="PENDING->REROUTED">
+<line x1="518.0" y1="271.0" x2="646.0" y2="154.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="518.0" y1="271.0" x2="646.0" y2="154.0" stroke="#39835a" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-available)" opacity="0.88"/>
+</g>
+<g data-edge="PENDING->RUNNING">
+<line x1="558.0" y1="300.0" x2="612.0" y2="300.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="558.0" y1="300.0" x2="612.0" y2="300.0" stroke="#c66a2e" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-owned)" opacity="0.88"/>
+</g>
+<g data-edge="PENDING_RECOVERY->REROUTED">
+<line x1="554.0" y1="581.0" x2="606.0" y2="154.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="554.0" y1="581.0" x2="606.0" y2="154.0" stroke="#39835a" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-available)" opacity="0.88"/>
+</g>
+<g data-edge="REGISTERED->CONCURRENCY_CONTROLLED">
+<line x1="338.0" y1="278.0" x2="382.0" y2="143.0" stroke="#fbf8f5" stroke-width="3.25" stroke-linecap="round" opacity="0.65"/>
+<line x1="338.0" y1="278.0" x2="382.0" y2="143.0" stroke="#c7506e" stroke-width="1.85" stroke-linecap="round" marker-end="url(#arrow-concurrency)" opacity="0.88"/>
+</g>
+<g data-edge="REGISTERED->CONCURRENCY_CONTROLLED_FINAL">
+<line x1="250.0" y1="329.0" x2="250.0" y2="456.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="250.0" y1="329.0" x2="250.0" y2="456.0" stroke="#677084" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-final)" opacity="0.88"/>
+</g>
+<g data-edge="REGISTERED->PENDING">
+<line x1="338.0" y1="300.0" x2="382.0" y2="300.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="338.0" y1="300.0" x2="382.0" y2="300.0" stroke="#c66a2e" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-owned)" opacity="0.88"/>
+</g>
+<g data-edge="REROUTED->CONCURRENCY_CONTROLLED">
+<line x1="602.0" y1="135.0" x2="558.0" y2="135.0" stroke="#fbf8f5" stroke-width="3.25" stroke-linecap="round" opacity="0.65"/>
+<line x1="602.0" y1="135.0" x2="558.0" y2="135.0" stroke="#c7506e" stroke-width="1.85" stroke-linecap="round" marker-end="url(#arrow-concurrency)" opacity="0.88"/>
+</g>
+<g data-edge="REROUTED->PENDING">
+<line x1="642.0" y1="154.0" x2="514.0" y2="271.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="642.0" y1="154.0" x2="514.0" y2="271.0" stroke="#c66a2e" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-owned)" opacity="0.88"/>
+</g>
+<g data-edge="RESUMED->FAILED">
+<line x1="1248.0" y1="149.0" x2="1342.0" y2="405.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="1248.0" y1="149.0" x2="1342.0" y2="405.0" stroke="#677084" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-final)" opacity="0.88"/>
+</g>
+<g data-edge="RESUMED->KILLED">
+<line x1="1188.0" y1="154.0" x2="1132.0" y2="456.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="1188.0" y1="154.0" x2="1132.0" y2="456.0" stroke="#b95a3d" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-start)" opacity="0.88"/>
+</g>
+<g data-edge="RESUMED->PAUSED">
+<line x1="1072.0" y1="135.0" x2="1018.0" y2="135.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="1072.0" y1="135.0" x2="1018.0" y2="135.0" stroke="#c66a2e" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-owned)" opacity="0.88"/>
+</g>
+<g data-edge="RESUMED->RETRY">
+<line x1="1114.0" y1="154.0" x2="788.0" y2="503.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="1114.0" y1="154.0" x2="788.0" y2="503.0" stroke="#39835a" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-available)" opacity="0.88"/>
+</g>
+<g data-edge="RESUMED->SUCCESS">
+<line x1="1248.0" y1="101.0" x2="1342.0" y2="215.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="1248.0" y1="101.0" x2="1342.0" y2="215.0" stroke="#677084" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-final)" opacity="0.88"/>
+</g>
+<g data-edge="RETRY->PENDING">
+<line x1="612.0" y1="467.0" x2="478.0" y2="329.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="612.0" y1="467.0" x2="478.0" y2="329.0" stroke="#c66a2e" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-owned)" opacity="0.88"/>
+</g>
+<g data-edge="RUNNING->FAILED">
+<line x1="788.0" y1="324.0" x2="1342.0" y2="405.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="788.0" y1="324.0" x2="1342.0" y2="405.0" stroke="#677084" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-final)" opacity="0.88"/>
+</g>
+<g data-edge="RUNNING->KILLED">
+<line x1="752.0" y1="329.0" x2="1072.0" y2="467.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="752.0" y1="329.0" x2="1072.0" y2="467.0" stroke="#b95a3d" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-start)" opacity="0.88"/>
+</g>
+<g data-edge="RUNNING->PAUSED">
+<line x1="748.0" y1="271.0" x2="882.0" y2="154.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="748.0" y1="271.0" x2="882.0" y2="154.0" stroke="#c66a2e" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-owned)" opacity="0.88"/>
+</g>
+<g data-edge="RUNNING->RETRY">
+<line x1="662.0" y1="329.0" x2="740.0" y2="456.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="662.0" y1="329.0" x2="740.0" y2="456.0" stroke="#39835a" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-available)" opacity="0.88"/>
+</g>
+<g data-edge="RUNNING->RUNNING_RECOVERY">
+<line x1="764.0" y1="329.0" x2="842.0" y2="590.0" stroke="#fbf8f5" stroke-width="3.25" stroke-linecap="round" opacity="0.65"/>
+<line x1="764.0" y1="329.0" x2="842.0" y2="590.0" stroke="#4f75c8" stroke-width="1.85" stroke-linecap="round" marker-end="url(#arrow-recovery)" opacity="0.88"/>
+</g>
+<g data-edge="RUNNING->SUCCESS">
+<line x1="788.0" y1="276.0" x2="1342.0" y2="215.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="788.0" y1="276.0" x2="1342.0" y2="215.0" stroke="#677084" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-final)" opacity="0.88"/>
+</g>
+<g data-edge="RUNNING_RECOVERY->REROUTED">
+<line x1="842.0" y1="610.0" x2="778.0" y2="143.0" stroke="#fbf8f5" stroke-width="3.05" stroke-linecap="round" opacity="0.65"/>
+<line x1="842.0" y1="610.0" x2="778.0" y2="143.0" stroke="#39835a" stroke-width="1.65" stroke-linecap="round" marker-end="url(#arrow-available)" opacity="0.88"/>
+</g>
+<circle cx="70" cy="300" r="22" fill="#f7f1ec" stroke="#b95a3d" stroke-width="2" filter="url(#shadow)"/>
+<text x="70" y="304" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui" font-size="11" font-weight="700" fill="#4f3228">START</text>
+<g data-status="REGISTERED">
+<rect x="162" y="271" width="176" height="58" rx="10" fill="#eaf7f0" stroke="#39835a" stroke-width="2" filter="url(#shadow)"/>
+<text x="250" y="302" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="700" fill="#244c36">REGISTERED</text>
+<text x="250" y="322" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" fill="#244c36" opacity="0.78">available / releases owner</text>
+</g>
+<g data-status="CONCURRENCY_CONTROLLED">
+<rect x="382" y="96" width="176" height="58" rx="10" fill="#fff0f4" stroke="#c7506e" stroke-width="2" filter="url(#shadow)"/>
+<text x="470" y="118" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="700" fill="#6c2b3d">CONCURRENCY</text>
+<text x="470" y="133" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="700" fill="#6c2b3d">CONTROLLED</text>
+<text x="470" y="147" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" fill="#6c2b3d" opacity="0.78">releases owner</text>
+</g>
+<g data-status="REROUTED">
+<rect x="602" y="96" width="176" height="58" rx="10" fill="#eaf7f0" stroke="#39835a" stroke-width="2" filter="url(#shadow)"/>
+<text x="690" y="127" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="700" fill="#244c36">REROUTED</text>
+<text x="690" y="147" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" fill="#244c36" opacity="0.78">available / releases owner</text>
+</g>
+<g data-status="PAUSED">
+<rect x="842" y="96" width="176" height="58" rx="10" fill="#fff3e6" stroke="#c66a2e" stroke-width="2" filter="url(#shadow)"/>
+<text x="930" y="127" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="700" fill="#5c351f">PAUSED</text>
+<text x="930" y="147" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" fill="#5c351f" opacity="0.78">owned</text>
+</g>
+<g data-status="RESUMED">
+<rect x="1072" y="96" width="176" height="58" rx="10" fill="#fff3e6" stroke="#c66a2e" stroke-width="2" filter="url(#shadow)"/>
+<text x="1160" y="127" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="700" fill="#5c351f">RESUMED</text>
+<text x="1160" y="147" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" fill="#5c351f" opacity="0.78">owned</text>
+</g>
+<g data-status="PENDING">
+<rect x="382" y="271" width="176" height="58" rx="10" fill="#fff3e6" stroke="#c66a2e" stroke-width="2" filter="url(#shadow)"/>
+<text x="470" y="302" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="700" fill="#5c351f">PENDING</text>
+<text x="470" y="322" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" fill="#5c351f" opacity="0.78">owned</text>
+</g>
+<g data-status="RUNNING">
+<rect x="612" y="271" width="176" height="58" rx="10" fill="#fff3e6" stroke="#c66a2e" stroke-width="2" filter="url(#shadow)"/>
+<text x="700" y="302" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="700" fill="#5c351f">RUNNING</text>
+<text x="700" y="322" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" fill="#5c351f" opacity="0.78">owned</text>
+</g>
+<g data-status="SUCCESS">
+<rect x="1342" y="206" width="176" height="58" rx="10" fill="#f1f3f7" stroke="#677084" stroke-width="2" filter="url(#shadow)"/>
+<rect x="1347" y="211" width="166" height="48" rx="7" fill="none" stroke="#677084" stroke-width="1.2" opacity="0.55"/>
+<text x="1430" y="237" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="700" fill="#333b4a">SUCCESS</text>
+<text x="1430" y="257" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" fill="#333b4a" opacity="0.78">final</text>
+</g>
+<g data-status="FAILED">
+<rect x="1342" y="356" width="176" height="58" rx="10" fill="#f1f3f7" stroke="#677084" stroke-width="2" filter="url(#shadow)"/>
+<rect x="1347" y="361" width="166" height="48" rx="7" fill="none" stroke="#677084" stroke-width="1.2" opacity="0.55"/>
+<text x="1430" y="387" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="700" fill="#333b4a">FAILED</text>
+<text x="1430" y="407" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" fill="#333b4a" opacity="0.78">final</text>
+</g>
+<g data-status="CONCURRENCY_CONTROLLED_FINAL">
+<rect x="162" y="456" width="176" height="58" rx="10" fill="#f1f3f7" stroke="#677084" stroke-width="2" filter="url(#shadow)"/>
+<rect x="167" y="461" width="166" height="48" rx="7" fill="none" stroke="#677084" stroke-width="1.2" opacity="0.55"/>
+<text x="250" y="478" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="700" fill="#333b4a">CONCURRENCY</text>
+<text x="250" y="493" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="700" fill="#333b4a">CONTROLLED_FINAL</text>
+<text x="250" y="507" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" fill="#333b4a" opacity="0.78">final</text>
+</g>
+<g data-status="RETRY">
+<rect x="612" y="456" width="176" height="58" rx="10" fill="#eaf7f0" stroke="#39835a" stroke-width="2" filter="url(#shadow)"/>
+<text x="700" y="487" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="700" fill="#244c36">RETRY</text>
+<text x="700" y="507" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" fill="#244c36" opacity="0.78">available / releases owner</text>
+</g>
+<g data-status="KILLED">
+<rect x="1072" y="456" width="176" height="58" rx="10" fill="#f7f1ec" stroke="#b95a3d" stroke-width="2" filter="url(#shadow)"/>
+<text x="1160" y="487" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="700" fill="#4f3228">KILLED</text>
+<text x="1160" y="507" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" fill="#4f3228" opacity="0.78">releases owner</text>
+</g>
+<g data-status="PENDING_RECOVERY">
+<rect x="382" y="581" width="176" height="58" rx="10" fill="#edf4ff" stroke="#4f75c8" stroke-width="2" filter="url(#shadow)"/>
+<text x="470" y="612" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="700" fill="#273d70">PENDING_RECOVERY</text>
+<text x="470" y="632" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" fill="#273d70" opacity="0.78">recovery / releases owner</text>
+</g>
+<g data-status="RUNNING_RECOVERY">
+<rect x="842" y="581" width="176" height="58" rx="10" fill="#edf4ff" stroke="#4f75c8" stroke-width="2" filter="url(#shadow)"/>
+<text x="930" y="612" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="13" font-weight="700" fill="#273d70">RUNNING_RECOVERY</text>
+<text x="930" y="632" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="10" fill="#273d70" opacity="0.78">recovery / releases owner</text>
+</g>
+<text x="48" y="680" font-family="Inter, ui-sans-serif, system-ui" font-size="13" font-weight="700" fill="#4f3228">Legend</text>
+<rect x="48" y="687" width="28" height="18" rx="5" fill="#eaf7f0" stroke="#39835a" stroke-width="1.5"/>
+<text x="86" y="700" font-family="Inter, ui-sans-serif, system-ui" font-size="12" fill="#244c36">available for runners</text>
+<rect x="318" y="687" width="28" height="18" rx="5" fill="#fff3e6" stroke="#c66a2e" stroke-width="1.5"/>
+<text x="356" y="700" font-family="Inter, ui-sans-serif, system-ui" font-size="12" fill="#5c351f">runner-owned</text>
+<rect x="588" y="687" width="28" height="18" rx="5" fill="#edf4ff" stroke="#4f75c8" stroke-width="1.5"/>
+<text x="626" y="700" font-family="Inter, ui-sans-serif, system-ui" font-size="12" fill="#273d70">recovery override</text>
+<rect x="858" y="687" width="28" height="18" rx="5" fill="#fff0f4" stroke="#c7506e" stroke-width="1.5"/>
+<text x="896" y="700" font-family="Inter, ui-sans-serif, system-ui" font-size="12" fill="#6c2b3d">concurrency control</text>
+<rect x="1128" y="687" width="28" height="18" rx="5" fill="#f1f3f7" stroke="#677084" stroke-width="1.5"/>
+<text x="1166" y="700" font-family="Inter, ui-sans-serif, system-ui" font-size="12" fill="#333b4a">final status</text>
+</svg>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,10 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   text or SVG diagram of the invocation status state machine directly from
   `pynenc.invocation.status`. The diagram is now committed to the repository at
   `docs/_static/invocation_state_machine.svg` and embedded in the README, the docs
-  landing page, and the invocation status guide. A pre-commit hook
-  (`invocation-state-machine-svg`) and a unit test
-  (`pynenc_tests/unit/docs/test_invocation_state_machine_svg.py`) keep the SVG and the
-  status configuration in sync.
+  landing page, and the invocation status guide.
 - **CLI app auto-discovery** (`pynenc/util/import_app.py`, `pynenc/cli/main_cli.py`):
   When `--app` is omitted, the CLI scans top-level Python files in the current
   directory and uses the only `Pynenc()` instance it finds. Multiple matches still

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,61 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2026-05-09
+
+### Added
+
+- **Invocation status state machine renderer** (`pynenc/invocation/status_graph.py`,
+  `pynenc/cli/status_cli.py`): New `pynenc status render` CLI command that produces a
+  text or SVG diagram of the invocation status state machine directly from
+  `pynenc.invocation.status`. The diagram is now committed to the repository at
+  `docs/_static/invocation_state_machine.svg` and embedded in the README, the docs
+  landing page, and the invocation status guide. A pre-commit hook
+  (`invocation-state-machine-svg`) and a unit test
+  (`pynenc_tests/unit/docs/test_invocation_state_machine_svg.py`) keep the SVG and the
+  status configuration in sync.
+- **CLI app auto-discovery** (`pynenc/util/import_app.py`, `pynenc/cli/main_cli.py`):
+  When `--app` is omitted, the CLI scans top-level Python files in the current
+  directory and uses the only `Pynenc()` instance it finds. Multiple matches still
+  require an explicit `--app`. The discovery scanner skips dunder/setup/conftest
+  files, prefers `tasks.py`/`app.py`/`pynenc_app.py`, and only imports files whose
+  source mentions `Pynenc` to avoid executing unrelated scripts. The same flow also
+  fuels `pynenc monitor` when a local app exists.
+- **CLI namespace `requires_app` flag** (`pynenc/cli/namespace.py`): Subcommands now
+  declare whether they need an app instance via
+  `parser.set_defaults(requires_app=...)` instead of relying on `getattr` fallbacks.
+  `status render` opts out so it can run without any user app.
+- **Tests**: Added unit coverage for monitor auto-discovery
+  (`pynenc_tests/unit/cli/test_main_cli.py`), the runner CLI auto-discovered label
+  (`pynenc_tests/unit/cli/test_runner_cli.py`), and the new auto-discovery branches
+  in `pynenc_tests/unit/util/test_find_app_instance.py` and
+  `test_import_app_filepath.py`.
+
+### Changed
+
+- **Removed `PENDING -> FAILED` transition** (`pynenc/invocation/status.py`):
+  The legacy "cycle-control fail without running" transition was removed.
+- **`distribute_calls` type narrowing** (`pynenc/task.py`): The helper now creates a
+  `ConcurrentInvocationGroup` or `DistributedInvocationGroup` via explicit branches
+  with `isinstance` checks, replacing the previous truthy filter and dynamic class
+  selection. Mismatches now raise `TypeError` instead of silently producing the
+  wrong invocation group.
+- **Documentation refresh** (`README.md`, `docs/getting_started/index.md`,
+  `docs/cli/index.md`, `docs/usage_guide/invocation_status.md`, `docs/index.md`):
+  Examples now show `pynenc runner start` / `pynenc monitor` (auto-discovery) and
+  fall back to `--app` only when more than one app exists. The invocation status
+  guide and landing page embed the new state machine SVG. The `KILLED` row and the
+  ownership-release description were rewritten to match the current state machine.
+- **Sphinx intersphinx mapping** (`docs/conf.py`): Renamed the `pynenc-mongodb`
+  entry to `pynenc-mongo` to match the published plugin name.
+
+### Fixed
+
+- **Hardened multi-thread shutdown** (`pynenc/runner/multi_thread_runner.py`):
+  The worker SIGTERM handler now installs `SIG_IGN` for SIGTERM as its first
+  action so a second termination signal cannot re-enter shutdown logging while it
+  is collecting process information.
+
 ## [0.2.2] - 2026-05-03
 
 ### Fixed

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -5,10 +5,10 @@ Reference for all Pynenc CLI commands and options.
 ## Basic Usage
 
 ```bash
-pynenc --app <module.attr> <command> [options]
+pynenc <command> [options]
 ```
 
-The `--app` option tells Pynenc where to find your `Pynenc()` instance. It accepts:
+When the current directory contains exactly one importable Python file with a `Pynenc()` instance, the CLI can find it automatically. Use `--app` when a project has more than one app or when you run the command from another directory. It accepts:
 
 | Format           | Example            | How it works                                                                |
 | ---------------- | ------------------ | --------------------------------------------------------------------------- |
@@ -31,7 +31,7 @@ def add(x: int, y: int) -> int:
 Then run with:
 
 ```bash
-pynenc --app tasks.app runner start
+pynenc runner start
 ```
 
 ```{note}
@@ -40,16 +40,22 @@ The colon format (`module:variable`) is **not** supported. Use dot notation: `ta
 
 ## Global Options
 
-| Option            | Description                                                                              |
-| ----------------- | ---------------------------------------------------------------------------------------- |
-| `--app MODULE`    | Dotted path to module with `Pynenc()` instance (required for `runner` and `show_config`) |
-| `-v`, `--verbose` | Enable debug-level logging output                                                        |
+| Option            | Description                                                                                                |
+| ----------------- | ---------------------------------------------------------------------------------------------------------- |
+| `--app MODULE`    | Dotted path to module with `Pynenc()` instance. Optional when exactly one local app can be auto-discovered |
+| `-v`, `--verbose` | Enable debug-level logging output                                                                          |
 
 ## Commands
 
 ### `runner start`
 
 Start a task runner for the specified application.
+
+```bash
+pynenc runner start
+```
+
+If auto-discovery finds more than one app, specify the one to run:
 
 ```bash
 pynenc --app myapp.tasks.app runner start
@@ -62,7 +68,7 @@ To stop the runner, send `SIGINT` (`Ctrl+C`) or `SIGTERM`. The runner shuts down
 **Example with environment variable override**:
 
 ```bash
-PYNENC__RUNNER_CLS=ThreadRunner pynenc --app myapp.tasks.app runner start
+PYNENC__RUNNER_CLS=ThreadRunner pynenc runner start
 ```
 
 ### `runner show_config`
@@ -70,7 +76,7 @@ PYNENC__RUNNER_CLS=ThreadRunner pynenc --app myapp.tasks.app runner start
 Display the runner configuration for the application.
 
 ```bash
-pynenc --app myapp.tasks.app runner show_config
+pynenc runner show_config
 ```
 
 ### `show_config`
@@ -78,7 +84,17 @@ pynenc --app myapp.tasks.app runner show_config
 Display the full application configuration, including all components and their settings.
 
 ```bash
-pynenc --app myapp.tasks.app show_config
+pynenc show_config
+```
+
+### `status render`
+
+Render the built-in invocation status state machine. This command does not need
+an app instance because it reads the status configuration from pynenc itself.
+
+```bash
+pynenc status render
+pynenc status render --format svg --output docs/_static/invocation_state_machine.svg
 ```
 
 ### `monitor`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "redis": ("https://redis-py.readthedocs.io/en/stable/", None),
     "pynenc-redis": ("https://pynenc-redis.readthedocs.io/en/latest/", None),
-    "pynenc-mongodb": ("https://pynenc-mongodb.readthedocs.io/en/latest/", None),
+    "pynenc-mongo": ("https://pynenc-mongo.readthedocs.io/en/latest/", None),
     "pynenc-rabbitmq": ("https://pynenc-rabbitmq.readthedocs.io/en/latest/", None),
 }
 

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -59,7 +59,13 @@ The task runs in the calling thread. No runner process is needed.
 For actual distributed execution, start a runner in one terminal:
 
 ```bash
-pynenc --app=tasks.app runner start
+pynenc runner start
+```
+
+The CLI auto-discovers the app when the current directory contains exactly one importable Python file with a `Pynenc()` instance. In this tutorial that is `tasks.py`. If a project has more than one app, or if you run the command from another directory, pass it explicitly:
+
+```bash
+pynenc --app tasks.app runner start
 ```
 
 In another terminal or script:
@@ -129,7 +135,7 @@ app = (
 Start the runner:
 
 ```bash
-pynenc --app=tasks.app runner start
+pynenc runner start
 ```
 
 Your tasks now route through Redis.
@@ -140,8 +146,10 @@ Install the monitoring extra and start Pynmon:
 
 ```bash
 pip install pynenc[monitor]
-pynenc --app=tasks.app monitor
+pynenc monitor
 ```
+
+If more than one app is available, choose one with `--app tasks.app`.
 
 Open `http://localhost:8000` to see invocations, runners, and task timelines.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,6 +112,23 @@ line of call-site code.
 
 ---
 
+## Invocation State Machine
+
+Every invocation moves through the same validated status graph. The diagram is
+generated from `pynenc.invocation.status`, so the documentation follows the
+implementation when states or transitions change.
+
+:::{image} \_static/invocation_state_machine.svg
+:alt: Pynenc invocation status state machine
+:width: 100%
+:class: shadow
+:::
+
+See {doc}`usage_guide/invocation_status` for the state definitions,
+ownership rules, and recovery transitions.
+
+---
+
 ## Pluggable Backends
 
 The core ships with in-memory and SQLite backends. Production backends are

--- a/docs/usage_guide/invocation_status.md
+++ b/docs/usage_guide/invocation_status.md
@@ -6,6 +6,14 @@ The invocation status system is a core component of Pynenc that manages the life
 
 Every task invocation in Pynenc progresses through a series of states from registration to completion. The status system enforces valid state transitions, tracks which runner owns each invocation, and enables automatic recovery when runners become unresponsive.
 
+The diagram below is generated from `pynenc/invocation/status.py`. If a status or transition changes, `pynenc status render --format svg --output docs/_static/invocation_state_machine.svg` updates this SVG and the tests check that it stays aligned with the implementation.
+
+```{image} ../_static/invocation_state_machine.svg
+:alt: Pynenc invocation status state machine
+:width: 100%
+:class: shadow
+```
+
 ## All Invocation Statuses
 
 | Status                         | Description                                                                |
@@ -15,7 +23,7 @@ Every task invocation in Pynenc progresses through a series of states from regis
 | `RUNNING`                      | Task is currently executing (owned by runner)                              |
 | `PAUSED`                       | Task execution is paused (owned by runner)                                 |
 | `RESUMED`                      | Task execution has been resumed after pause (owned by runner)              |
-| `KILLED`                       | Task execution was terminated                                              |
+| `KILLED`                       | Task execution was terminated and can be rerouted                          |
 | `RETRY`                        | Task finished with a retriable exception, available for re-execution       |
 | `SUCCESS`                      | Task completed successfully (final)                                        |
 | `FAILED`                       | Task finished with an exception (final)                                    |
@@ -82,7 +90,7 @@ The status system tracks which runner owns each invocation:
 
 - **Ownership Acquisition**: When a runner picks up an invocation (REGISTERED → PENDING), it acquires ownership.
 - **Ownership Validation**: Transitions from owned statuses (PENDING, RUNNING, etc.) require the requesting runner to be the owner.
-- **Ownership Release**: Final statuses and rerouted statuses release ownership, making the invocation available for other runners.
+- **Ownership Release**: Statuses such as `REROUTED`, `RETRY`, `KILLED`, recovery states, and final states release ownership before the next transition.
 - **Ownership Override**: Recovery statuses (PENDING_RECOVERY, RUNNING_RECOVERY) bypass ownership validation to recover stuck invocations.
 
 ## Runner Heartbeat and Recovery
@@ -144,7 +152,7 @@ When `reroute_on_concurrency_control=False`, blocked invocations receive CONCURR
 
 Use Pynmon to visualize invocation status transitions:
 
-1. Start the monitor: `pynenc --app your_app monitor`
+1. Start the monitor: `pynenc monitor` when the app can be discovered, or `pynenc --app your_app monitor` when you need to select one explicitly
 2. Navigate to the Timeline view to see status changes over time
 3. Click on individual invocations to see their full status history
 

--- a/pynenc/cli/main_cli.py
+++ b/pynenc/cli/main_cli.py
@@ -2,12 +2,49 @@ import argparse
 import logging
 import sys
 import traceback
+from typing import TYPE_CHECKING
 
 from pynenc.cli.config_cli import add_config_subparser
 from pynenc.cli.monitor_cli import add_monitor_subparser
 from pynenc.cli.namespace import PynencCLINamespace
 from pynenc.cli.runner_cli import add_runner_subparser
+from pynenc.cli.status_cli import add_status_subparser
 from pynenc.util.import_app import find_app_instance
+
+if TYPE_CHECKING:
+    from pynenc.app import Pynenc
+
+
+def _set_auto_discovered_app_label(
+    args: PynencCLINamespace, app_instance: "Pynenc"
+) -> None:
+    args.app_instance = app_instance
+    if not args.app:
+        args.app = f"auto-discovered app_id={app_instance.app_id}"
+
+
+def _try_find_monitor_app() -> "Pynenc | None":
+    """Try monitor auto-discovery without failing the command when no local app exists."""
+    try:
+        return find_app_instance(None)
+    except ValueError:
+        return None
+
+
+def _resolve_app_for_command(args: PynencCLINamespace) -> None:
+    """Attach app instance to args when the selected command requires one."""
+    if not args.requires_app:
+        return
+
+    if args.command == "monitor" and not args.app:
+        app_instance = _try_find_monitor_app()
+        if app_instance is None:
+            return
+        _set_auto_discovered_app_label(args, app_instance)
+        return
+
+    app_instance = find_app_instance(args.app)
+    _set_auto_discovered_app_label(args, app_instance)
 
 
 def main() -> None:
@@ -18,8 +55,9 @@ def main() -> None:
     sets up logging, and executes the appropriate subcommand function based on the user input.
 
     The CLI supports various subcommands for different functionalities, such as running tasks
-    and configuring the application. The `--app` parameter is required for most commands, but optional for monitoring which can
-    auto-discover apps.
+    and configuring the application. The `--app` parameter is optional when the
+    current directory contains exactly one importable `Pynenc()` instance; use it
+    explicitly when more than one app exists or when running outside the app directory.
 
     The main steps include:
     - Parsing command line arguments with `argparse`.
@@ -35,6 +73,7 @@ def main() -> None:
         "--app",
         help=(
             "Dotted path to the module containing your Pynenc() instance. "
+            "Optional when the current directory contains exactly one local app. "
             "Examples: 'tasks.app' (loads tasks.py), "
             "'mypackage.tasks' (imports mypackage.tasks), "
             "'path/to/tasks.py' (loads file directly)"
@@ -51,6 +90,7 @@ def main() -> None:
     add_runner_subparser(subparsers)
     add_config_subparser(subparsers)
     add_monitor_subparser(subparsers)
+    add_status_subparser(subparsers)
 
     # Parse the arguments into custom namespace PynencCLINamespace
     args = PynencCLINamespace()
@@ -60,14 +100,8 @@ def main() -> None:
     log_level = logging.DEBUG if args.verbose else logging.WARNING
     logging.basicConfig(level=log_level, format="%(levelname)s: %(message)s")
 
-    # Only require --app for non-monitor commands
-    if args.command != "monitor" and not args.app:
-        parser.error("the --app argument is required for this command")
-
     try:
-        if args.app:
-            app_instance = find_app_instance(args.app)
-            args.app_instance = app_instance
+        _resolve_app_for_command(args)
         args.func(args)
     except ValueError as e:
         logging.error(f"Failed to load application: {e}")

--- a/pynenc/cli/namespace.py
+++ b/pynenc/cli/namespace.py
@@ -25,4 +25,5 @@ class PynencCLINamespace(argparse.Namespace):
 
     app: str | None = None
     verbose: bool | None = None
+    requires_app: bool = True
     app_instance: "Pynenc | None" = None

--- a/pynenc/cli/status_cli.py
+++ b/pynenc/cli/status_cli.py
@@ -1,0 +1,70 @@
+import argparse
+import sys
+from pathlib import Path
+
+from pynenc.invocation.status_graph import DEFAULT_OUTPUT_PATH, render_svg, render_text
+
+
+def add_status_subparser(subparsers: argparse._SubParsersAction) -> None:
+    """Add invocation status inspection commands to the main CLI."""
+    status_parser = subparsers.add_parser(
+        "status", help="Inspect the invocation status state machine"
+    )
+    status_subparsers = status_parser.add_subparsers(
+        dest="status_command", required=True
+    )
+
+    render_parser = status_subparsers.add_parser(
+        "render", help="Render the invocation status state machine"
+    )
+    render_parser.add_argument(
+        "--format",
+        choices=("text", "svg"),
+        default="text",
+        help="Output format (default: text)",
+    )
+    render_parser.add_argument(
+        "--output",
+        type=Path,
+        help=(
+            "File to write or check. Defaults to stdout, except SVG --check uses "
+            f"the docs SVG path ({DEFAULT_OUTPUT_PATH})."
+        ),
+    )
+    render_parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if the output file does not match the current state machine",
+    )
+    render_parser.set_defaults(func=render_status_command, requires_app=False)
+
+
+def render_status_command(args: argparse.Namespace) -> None:
+    """Render or check the invocation status state machine."""
+    rendered = render_svg() if args.format == "svg" else render_text()
+    output: Path | None = args.output
+    if args.check:
+        if output is None:
+            if args.format == "svg":
+                output = DEFAULT_OUTPUT_PATH
+            else:
+                print("--check requires --output when --format text", file=sys.stderr)
+                sys.exit(1)
+        if not output.exists():
+            print(f"Missing generated file: {output}", file=sys.stderr)
+            sys.exit(1)
+        if output.read_text(encoding="utf-8") != rendered:
+            print(
+                f"{output} is stale. Run: pynenc status render --format {args.format} --output {output}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        return
+
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered, encoding="utf-8")
+        print(f"Wrote {output}")
+        return
+
+    print(rendered, end="")

--- a/pynenc/invocation/status.py
+++ b/pynenc/invocation/status.py
@@ -31,7 +31,7 @@ class InvocationStatus(StrEnum):
     :attr:`~pynenc.conf.config_pynenc.ConfigPynenc.max_pending_seconds`.
 
     ```{note}
-    FAILED, RETRY, and SUCCESS are final statuses that terminate the invocation lifecycle.
+    SUCCESS, FAILED, and CONCURRENCY_CONTROLLED_FINAL are final statuses that terminate the invocation lifecycle.
     ```
 
     :cvar REGISTERED: The task call has been routed and is registered
@@ -242,15 +242,12 @@ _CONFIG: Final[StatusConfiguration] = StatusConfiguration(
             releases_ownership=True,
         ),
         InvocationStatus.PENDING: StatusDefinition(
-            # An invocation can FAILED without running by the CYCLE-CONTROL mechanism
-            # to avoid deadlocks.
             # PENDING_RECOVERY is for timeout recovery without ownership validation
             allowed_transitions=frozenset(
                 {
                     InvocationStatus.RUNNING,
                     InvocationStatus.KILLED,
                     InvocationStatus.REROUTED,
-                    InvocationStatus.FAILED,
                     InvocationStatus.PENDING_RECOVERY,
                 }
             ),

--- a/pynenc/invocation/status_graph.py
+++ b/pynenc/invocation/status_graph.py
@@ -1,0 +1,571 @@
+"""Render the invocation status state machine from the status configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html import escape
+from pathlib import Path
+from typing import Final, Literal
+
+from pynenc.invocation.status import InvocationStatus, StatusDefinition, _CONFIG
+
+DEFAULT_OUTPUT_PATH: Final[Path] = (
+    Path(__file__).resolve().parents[2]
+    / "docs"
+    / "_static"
+    / "invocation_state_machine.svg"
+)
+
+NodeKey = InvocationStatus | str
+Side = Literal["left", "right", "top", "bottom"]
+
+NODE_WIDTH: Final[int] = 176
+NODE_HEIGHT: Final[int] = 58
+NODE_GAP: Final[int] = 16
+
+POSITIONS: Final[dict[NodeKey, tuple[int, int]]] = {
+    "START": (70, 300),
+    InvocationStatus.REGISTERED: (250, 300),
+    InvocationStatus.CONCURRENCY_CONTROLLED: (470, 125),
+    InvocationStatus.REROUTED: (690, 125),
+    InvocationStatus.PAUSED: (930, 125),
+    InvocationStatus.RESUMED: (1160, 125),
+    InvocationStatus.PENDING: (470, 300),
+    InvocationStatus.RUNNING: (700, 300),
+    InvocationStatus.SUCCESS: (1430, 235),
+    InvocationStatus.FAILED: (1430, 385),
+    InvocationStatus.CONCURRENCY_CONTROLLED_FINAL: (250, 485),
+    InvocationStatus.RETRY: (700, 485),
+    InvocationStatus.KILLED: (1160, 485),
+    InvocationStatus.PENDING_RECOVERY: (470, 610),
+    InvocationStatus.RUNNING_RECOVERY: (930, 610),
+}
+
+PALETTE: Final[dict[str, tuple[str, str, str]]] = {
+    "start": ("#f7f1ec", "#b95a3d", "#4f3228"),
+    "available": ("#eaf7f0", "#39835a", "#244c36"),
+    "owned": ("#fff3e6", "#c66a2e", "#5c351f"),
+    "recovery": ("#edf4ff", "#4f75c8", "#273d70"),
+    "concurrency": ("#fff0f4", "#c7506e", "#6c2b3d"),
+    "final": ("#f1f3f7", "#677084", "#333b4a"),
+}
+
+
+@dataclass(frozen=True)
+class RouteSpec:
+    start_side: Side
+    end_side: Side
+    start_offset: int = 0
+    end_offset: int = 0
+
+
+S = InvocationStatus
+
+EDGE_ROUTES: Final[dict[tuple[str, str], RouteSpec]] = {
+    ("START", S.REGISTERED.name): RouteSpec("right", "left"),
+    (S.REGISTERED.name, S.CONCURRENCY_CONTROLLED.name): RouteSpec(
+        "right", "left", -22, 18
+    ),
+    (S.REGISTERED.name, S.PENDING.name): RouteSpec("right", "left"),
+    (S.REGISTERED.name, S.CONCURRENCY_CONTROLLED_FINAL.name): RouteSpec(
+        "bottom", "top"
+    ),
+    (S.CONCURRENCY_CONTROLLED.name, S.REROUTED.name): RouteSpec(
+        "right", "left", -10, -10
+    ),
+    (S.REROUTED.name, S.CONCURRENCY_CONTROLLED.name): RouteSpec(
+        "left", "right", 10, 10
+    ),
+    (S.PENDING.name, S.REROUTED.name): RouteSpec("top", "bottom", 48, -44),
+    (S.REROUTED.name, S.PENDING.name): RouteSpec("bottom", "top", -48, 44),
+    (S.PENDING.name, S.RUNNING.name): RouteSpec("right", "left"),
+    (S.PENDING.name, S.PENDING_RECOVERY.name): RouteSpec("bottom", "top", -42, -42),
+    (S.PENDING.name, S.KILLED.name): RouteSpec("bottom", "left", 54, 18),
+    (S.PENDING_RECOVERY.name, S.REROUTED.name): RouteSpec("top", "bottom", 84, -84),
+    (S.RUNNING.name, S.PAUSED.name): RouteSpec("top", "bottom", 48, -48),
+    (S.RUNNING.name, S.SUCCESS.name): RouteSpec("right", "left", -24, -20),
+    (S.RUNNING.name, S.RETRY.name): RouteSpec("bottom", "top", -38, 40),
+    (S.RUNNING.name, S.FAILED.name): RouteSpec("right", "left", 24, 20),
+    (S.RUNNING.name, S.KILLED.name): RouteSpec("bottom", "left", 52, -18),
+    (S.RUNNING.name, S.RUNNING_RECOVERY.name): RouteSpec("bottom", "left", 64, -20),
+    (S.RUNNING_RECOVERY.name, S.REROUTED.name): RouteSpec("left", "right", 0, 18),
+    (S.PAUSED.name, S.RESUMED.name): RouteSpec("right", "left", -10, -10),
+    (S.RESUMED.name, S.PAUSED.name): RouteSpec("left", "right", 10, 10),
+    (S.PAUSED.name, S.KILLED.name): RouteSpec("bottom", "top", 52, 42),
+    (S.RESUMED.name, S.SUCCESS.name): RouteSpec("right", "left", -24, -20),
+    (S.RESUMED.name, S.FAILED.name): RouteSpec("right", "left", 24, 20),
+    (S.RESUMED.name, S.RETRY.name): RouteSpec("bottom", "right", -46, 18),
+    (S.RESUMED.name, S.KILLED.name): RouteSpec("bottom", "top", 28, -28),
+    (S.RETRY.name, S.PENDING.name): RouteSpec("left", "bottom", -18, 8),
+    (S.KILLED.name, S.REROUTED.name): RouteSpec("left", "right", 18, 18),
+}
+
+
+def render_svg() -> str:
+    """Return the SVG representation generated from the current status config."""
+    _validate_layout()
+    edges = list(_iter_edges())
+    parts = [_svg_header(), _defs()]
+    parts.extend(_render_edge(source, target) for source, target in edges)
+    parts.extend(_render_node(node) for node in POSITIONS)
+    parts.append(_render_legend())
+    parts.append("</svg>\n")
+    return "".join(parts)
+
+
+def render_text() -> str:
+    """Return a plain-text representation of the invocation status graph."""
+    parts = [
+        "Invocation status state machine",
+        "Generated from pynenc.invocation.status",
+        "",
+        "Transitions:",
+    ]
+    for source, target in _iter_edges():
+        parts.append(f"  {_node_name(source)} -> {target.name}")
+    parts.extend(["", "Statuses:"])
+    for status in InvocationStatus:
+        definition = _CONFIG.get_definition(status)
+        parts.append(f"  {status.name}: {_badge_for(definition)}")
+    return "\n".join(parts) + "\n"
+
+
+def _validate_layout() -> None:
+    positioned_statuses: set[InvocationStatus] = {
+        node for node in POSITIONS if isinstance(node, InvocationStatus)
+    }
+    missing_statuses = [
+        status for status in InvocationStatus if status not in positioned_statuses
+    ]
+    if missing_statuses:
+        missing_names = ", ".join(sorted(status.name for status in missing_statuses))
+        raise ValueError(f"Missing diagram positions for: {missing_names}")
+
+    positioned_nodes = list(POSITIONS)
+    for index, first in enumerate(positioned_nodes):
+        for second in positioned_nodes[index + 1 :]:
+            if _bounds_overlap(_node_bounds(first), _node_bounds(second), NODE_GAP):
+                raise ValueError(
+                    "Overlapping diagram nodes: "
+                    f"{_node_name(first)} and {_node_name(second)}"
+                )
+
+    for source, target in _iter_edges():
+        if blocker := _edge_crosses_non_endpoint_node(source, target):
+            source_name = _node_name(source)
+            raise ValueError(
+                "Diagram edge crosses another node: "
+                f"{source_name}->{target.name} crosses {_node_name(blocker)}"
+            )
+
+
+def _node_bounds(node: NodeKey) -> tuple[float, float, float, float]:
+    x, y = POSITIONS[node]
+    if node == "START":
+        radius = 22
+        return x - radius, y - radius, x + radius, y + radius
+    return (
+        x - NODE_WIDTH / 2,
+        y - NODE_HEIGHT / 2,
+        x + NODE_WIDTH / 2,
+        y + NODE_HEIGHT / 2,
+    )
+
+
+def _bounds_overlap(
+    first: tuple[float, float, float, float],
+    second: tuple[float, float, float, float],
+    padding: int,
+) -> bool:
+    first_left, first_top, first_right, first_bottom = first
+    second_left, second_top, second_right, second_bottom = second
+    return not (
+        first_right + padding <= second_left
+        or second_right + padding <= first_left
+        or first_bottom + padding <= second_top
+        or second_bottom + padding <= first_top
+    )
+
+
+def _edge_crosses_non_endpoint_node(
+    source: NodeKey, target: InvocationStatus
+) -> NodeKey | None:
+    source_name = _node_name(source)
+    target_name = target.name
+    start_x, start_y, end_x, end_y = _edge_points(source, target)
+    for node in POSITIONS:
+        node_name = _node_name(node)
+        if node_name in {source_name, target_name}:
+            continue
+        if _segment_intersects_bounds(
+            start_x, start_y, end_x, end_y, _node_bounds(node)
+        ):
+            return node
+    return None
+
+
+def _segment_intersects_bounds(
+    start_x: float,
+    start_y: float,
+    end_x: float,
+    end_y: float,
+    bounds: tuple[float, float, float, float],
+) -> bool:
+    left, top, right, bottom = bounds
+    if _point_inside_bounds(start_x, start_y, bounds) or _point_inside_bounds(
+        end_x, end_y, bounds
+    ):
+        return True
+    bound_segments = (
+        (left, top, right, top),
+        (right, top, right, bottom),
+        (right, bottom, left, bottom),
+        (left, bottom, left, top),
+    )
+    return any(
+        _segments_intersect(start_x, start_y, end_x, end_y, *bound_segment)
+        for bound_segment in bound_segments
+    )
+
+
+def _point_inside_bounds(
+    point_x: float, point_y: float, bounds: tuple[float, float, float, float]
+) -> bool:
+    left, top, right, bottom = bounds
+    return left < point_x < right and top < point_y < bottom
+
+
+def _segments_intersect(
+    first_start_x: float,
+    first_start_y: float,
+    first_end_x: float,
+    first_end_y: float,
+    second_start_x: float,
+    second_start_y: float,
+    second_end_x: float,
+    second_end_y: float,
+) -> bool:
+    first_orientation = _orientation(
+        first_start_x,
+        first_start_y,
+        first_end_x,
+        first_end_y,
+        second_start_x,
+        second_start_y,
+    )
+    second_orientation = _orientation(
+        first_start_x,
+        first_start_y,
+        first_end_x,
+        first_end_y,
+        second_end_x,
+        second_end_y,
+    )
+    third_orientation = _orientation(
+        second_start_x,
+        second_start_y,
+        second_end_x,
+        second_end_y,
+        first_start_x,
+        first_start_y,
+    )
+    fourth_orientation = _orientation(
+        second_start_x,
+        second_start_y,
+        second_end_x,
+        second_end_y,
+        first_end_x,
+        first_end_y,
+    )
+    if (
+        first_orientation != second_orientation
+        and third_orientation != fourth_orientation
+    ):
+        return True
+    return (
+        first_orientation == 0
+        and _point_on_segment(
+            first_start_x,
+            first_start_y,
+            second_start_x,
+            second_start_y,
+            first_end_x,
+            first_end_y,
+        )
+        or second_orientation == 0
+        and _point_on_segment(
+            first_start_x,
+            first_start_y,
+            second_end_x,
+            second_end_y,
+            first_end_x,
+            first_end_y,
+        )
+        or third_orientation == 0
+        and _point_on_segment(
+            second_start_x,
+            second_start_y,
+            first_start_x,
+            first_start_y,
+            second_end_x,
+            second_end_y,
+        )
+        or fourth_orientation == 0
+        and _point_on_segment(
+            second_start_x,
+            second_start_y,
+            first_end_x,
+            first_end_y,
+            second_end_x,
+            second_end_y,
+        )
+    )
+
+
+def _orientation(
+    start_x: float,
+    start_y: float,
+    end_x: float,
+    end_y: float,
+    point_x: float,
+    point_y: float,
+) -> int:
+    value = (end_y - start_y) * (point_x - end_x) - (end_x - start_x) * (
+        point_y - end_y
+    )
+    if abs(value) < 1e-9:
+        return 0
+    return 1 if value > 0 else 2
+
+
+def _point_on_segment(
+    start_x: float,
+    start_y: float,
+    point_x: float,
+    point_y: float,
+    end_x: float,
+    end_y: float,
+) -> bool:
+    return min(start_x, end_x) <= point_x <= max(start_x, end_x) and min(
+        start_y, end_y
+    ) <= point_y <= max(start_y, end_y)
+
+
+def _iter_edges() -> list[tuple[NodeKey, InvocationStatus]]:
+    edges: list[tuple[NodeKey, InvocationStatus]] = [
+        ("START", InvocationStatus.REGISTERED)
+    ]
+    for source, definition in sorted(
+        _CONFIG.definitions.items(),
+        key=lambda item: "" if item[0] is None else item[0].name,
+    ):
+        if source is None:
+            continue
+        for target in sorted(
+            definition.allowed_transitions, key=lambda status: status.name
+        ):
+            edges.append((source, target))
+    return edges
+
+
+def _svg_header() -> str:
+    return (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="760" '
+        'viewBox="0 0 1600 760" role="img" aria-labelledby="title desc">\n'
+        '<title id="title">Pynenc invocation status state machine</title>\n'
+        '<desc id="desc">Generated from pynenc.invocation.status. Shows allowed transitions, ownership, recovery, and final states.</desc>\n'
+        '<rect width="1600" height="760" rx="18" fill="#fbf8f5"/>\n'
+        '<text x="48" y="48" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" '
+        'font-size="24" font-weight="700" fill="#2f221d">Invocation status state machine</text>\n'
+        '<text x="48" y="74" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" '
+        'font-size="13" fill="#735d52">Generated from pynenc.invocation.status</text>\n'
+    )
+
+
+def _defs() -> str:
+    parts = [
+        "<defs>\n"
+        '<filter id="shadow" x="-15%" y="-25%" width="130%" height="160%">\n'
+        '<feDropShadow dx="0" dy="6" stdDeviation="5" flood-color="#3a241a" flood-opacity="0.13"/>\n'
+        "</filter>\n"
+    ]
+    for style, (_, stroke, _) in PALETTE.items():
+        parts.append(
+            f'<marker id="arrow-{style}" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">\n'
+            f'<path d="M0,0 L0,6 L8,3 z" fill="{stroke}"/>\n'
+            "</marker>\n"
+        )
+    parts.append("</defs>\n")
+    return "".join(parts)
+
+
+def _render_edge(source: NodeKey, target: InvocationStatus) -> str:
+    start_x, start_y, end_x, end_y = _edge_points(source, target)
+    style = _style_for(target, _CONFIG.get_definition(target))
+    _, stroke, _ = PALETTE[style]
+    marker = f"url(#arrow-{style})"
+    width = 1.85 if style in {"recovery", "concurrency"} else 1.65
+    source_name = _node_name(source)
+    return (
+        f'<g data-edge="{source_name}->{target.name}">\n'
+        f'<line x1="{start_x:.1f}" y1="{start_y:.1f}" x2="{end_x:.1f}" y2="{end_y:.1f}" '
+        f'stroke="#fbf8f5" stroke-width="{width + 1.4}" '
+        'stroke-linecap="round" opacity="0.65"/>\n'
+        f'<line x1="{start_x:.1f}" y1="{start_y:.1f}" x2="{end_x:.1f}" y2="{end_y:.1f}" '
+        f'stroke="{stroke}" stroke-width="{width}" '
+        f'stroke-linecap="round" marker-end="{marker}" opacity="0.88"/>\n'
+        "</g>\n"
+    )
+
+
+def _edge_points(
+    source: NodeKey, target: InvocationStatus
+) -> tuple[float, float, float, float]:
+    spec = EDGE_ROUTES.get(
+        (_node_name(source), target.name), _default_route(source, target)
+    )
+    start_x, start_y = _anchor(source, spec.start_side, spec.start_offset)
+    end_x, end_y = _anchor(target, spec.end_side, spec.end_offset)
+    return start_x, start_y, end_x, end_y
+
+
+def _default_route(source: NodeKey, target: InvocationStatus) -> RouteSpec:
+    source_x, source_y = POSITIONS[source]
+    target_x, target_y = POSITIONS[target]
+    if abs(target_x - source_x) >= abs(target_y - source_y):
+        if target_x >= source_x:
+            return RouteSpec("right", "left")
+        return RouteSpec("left", "right")
+    if target_y >= source_y:
+        return RouteSpec("bottom", "top")
+    return RouteSpec("top", "bottom")
+
+
+def _anchor(node: NodeKey, side: Side, offset: int) -> tuple[float, float]:
+    x, y = POSITIONS[node]
+    if node == "START":
+        radius = 22
+        if side == "right":
+            return x + radius, y + offset
+        if side == "left":
+            return x - radius, y + offset
+        if side == "top":
+            return x + offset, y - radius
+        return x + offset, y + radius
+
+    if side == "right":
+        return x + NODE_WIDTH / 2, y + offset
+    if side == "left":
+        return x - NODE_WIDTH / 2, y + offset
+    if side == "top":
+        return x + offset, y - NODE_HEIGHT / 2
+    return x + offset, y + NODE_HEIGHT / 2
+
+
+def _render_node(node: NodeKey) -> str:
+    x, y = POSITIONS[node]
+    if node == "START":
+        fill, stroke, text = PALETTE["start"]
+        return (
+            f'<circle cx="{x}" cy="{y}" r="22" fill="{fill}" stroke="{stroke}" stroke-width="2" filter="url(#shadow)"/>\n'
+            f'<text x="{x}" y="{y + 4}" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui" '
+            f'font-size="11" font-weight="700" fill="{text}">START</text>\n'
+        )
+    if not isinstance(node, InvocationStatus):
+        raise TypeError(f"Unsupported diagram node: {node}")
+
+    definition = _CONFIG.get_definition(node)
+    style = _style_for(node, definition)
+    fill, stroke, text_color = PALETTE[style]
+    rect_x = x - NODE_WIDTH // 2
+    rect_y = y - NODE_HEIGHT // 2
+    badge = _badge_for(definition)
+    title_lines = _split_label(node.name)
+    title_y = y - 7 if len(title_lines) == 2 else y + 2
+    parts = [
+        f'<g data-status="{node.name}">\n',
+        f'<rect x="{rect_x}" y="{rect_y}" width="{NODE_WIDTH}" height="{NODE_HEIGHT}" rx="10" '
+        f'fill="{fill}" stroke="{stroke}" stroke-width="2" filter="url(#shadow)"/>\n',
+    ]
+    if definition.is_final:
+        parts.append(
+            f'<rect x="{rect_x + 5}" y="{rect_y + 5}" width="{NODE_WIDTH - 10}" height="{NODE_HEIGHT - 10}" rx="7" '
+            f'fill="none" stroke="{stroke}" stroke-width="1.2" opacity="0.55"/>\n'
+        )
+    for index, line in enumerate(title_lines):
+        parts.append(
+            f'<text x="{x}" y="{title_y + (index * 15)}" text-anchor="middle" '
+            'font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" '
+            f'font-size="13" font-weight="700" fill="{text_color}">{escape(line)}</text>\n'
+        )
+    parts.append(
+        f'<text x="{x}" y="{y + 22}" text-anchor="middle" '
+        'font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" '
+        f'font-size="10" fill="{text_color}" opacity="0.78">{escape(badge)}</text>\n'
+    )
+    parts.append("</g>\n")
+    return "".join(parts)
+
+
+def _style_for(status: InvocationStatus, definition: StatusDefinition) -> str:
+    if definition.is_final:
+        return "final"
+    if definition.overrides_ownership or status.name.endswith("_RECOVERY"):
+        return "recovery"
+    if status.name.startswith("CONCURRENCY"):
+        return "concurrency"
+    if definition.requires_ownership or definition.acquires_ownership:
+        return "owned"
+    if definition.available_for_run:
+        return "available"
+    return "start"
+
+
+def _badge_for(definition: StatusDefinition) -> str:
+    labels: list[str] = []
+    if definition.available_for_run:
+        labels.append("available")
+    if definition.requires_ownership:
+        labels.append("owned")
+    if definition.overrides_ownership:
+        labels.append("recovery")
+    if definition.is_final:
+        labels.append("final")
+    if definition.releases_ownership and not definition.is_final:
+        labels.append("releases owner")
+    return " / ".join(labels) if labels else "transition"
+
+
+def _split_label(label: str) -> list[str]:
+    if len(label) <= 16:
+        return [label]
+    parts = label.split("_")
+    middle = max(1, len(parts) // 2)
+    return ["_".join(parts[:middle]), "_".join(parts[middle:])]
+
+
+def _render_legend() -> str:
+    items = [
+        ("available", "available for runners"),
+        ("owned", "runner-owned"),
+        ("recovery", "recovery override"),
+        ("concurrency", "concurrency control"),
+        ("final", "final status"),
+    ]
+    x = 48
+    y = 705
+    parts = [
+        '<text x="48" y="680" font-family="Inter, ui-sans-serif, system-ui" font-size="13" font-weight="700" fill="#4f3228">Legend</text>\n'
+    ]
+    for index, (style, label) in enumerate(items):
+        fill, stroke, text = PALETTE[style]
+        item_x = x + index * 270
+        parts.append(
+            f'<rect x="{item_x}" y="{y - 18}" width="28" height="18" rx="5" fill="{fill}" stroke="{stroke}" stroke-width="1.5"/>\n'
+            f'<text x="{item_x + 38}" y="{y - 5}" font-family="Inter, ui-sans-serif, system-ui" font-size="12" fill="{text}">{label}</text>\n'
+        )
+    return "".join(parts)
+
+
+def _node_name(node: NodeKey) -> str:
+    return node.name if isinstance(node, InvocationStatus) else node

--- a/pynenc/runner/multi_thread_runner.py
+++ b/pynenc/runner/multi_thread_runner.py
@@ -63,6 +63,10 @@ def thread_runner_process_main(
     app.logger.info(f"ThreadRunner process worker:{child_runner_id} started")
 
     def _handle_signal(signum: int, frame: Any) -> None:
+        # A second SIGTERM can arrive while shutdown diagnostics are collecting
+        # process information. Ignore repeated signals so logging cannot be
+        # re-entered from inside imports or stdlib helpers.
+        _signal.signal(_signal.SIGTERM, _signal.SIG_IGN)
         runner._log_shutdown(signum)
         raise KeyboardInterrupt  # trigger _on_stop via finally block
 

--- a/pynenc/task.py
+++ b/pynenc/task.py
@@ -19,6 +19,7 @@ from pynenc.invocation.conc_invocation import (
     ConcurrentInvocationGroup,
 )
 from pynenc.invocation.dist_invocation import (
+    DistributedInvocation,
     DistributedInvocationGroup,
 )
 from pynenc.identifiers.task_id import TaskId
@@ -447,20 +448,24 @@ def distribute_calls(
     # Prepare arguments with common_args merged in
     all_args = prepare_arguments(task, param_list, common_args)
 
-    # Standard processing - distribute calls normally
-    invocations = []
+    if task.app.conf.dev_mode_force_sync_tasks:
+        concurrent_invocations: list[ConcurrentInvocation] = []
+        for args in all_args:
+            invocation = task._call(args)
+            if not isinstance(invocation, ConcurrentInvocation):
+                raise TypeError(
+                    "dev_mode_force_sync_tasks must create ConcurrentInvocation"
+                )
+            concurrent_invocations.append(invocation)
+        return ConcurrentInvocationGroup(task, concurrent_invocations)
+
+    distributed_invocations: list[DistributedInvocation] = []
     for args in all_args:
         invocation = task._call(args)
-        if invocation:
-            invocations.append(invocation)
-
-    group_cls: type[BaseInvocationGroup]
-    if task.app.conf.dev_mode_force_sync_tasks:
-        group_cls = ConcurrentInvocationGroup
-    else:
-        group_cls = DistributedInvocationGroup
-
-    return group_cls(task, invocations)
+        if not isinstance(invocation, DistributedInvocation):
+            raise TypeError("distributed mode must create DistributedInvocation")
+        distributed_invocations.append(invocation)
+    return DistributedInvocationGroup(task, distributed_invocations)
 
 
 def distribute_batch_calls(

--- a/pynenc/util/import_app.py
+++ b/pynenc/util/import_app.py
@@ -4,6 +4,8 @@ Utilities for discovering and loading Pynenc application instances.
 The CLI uses ``--app`` to locate the user's ``Pynenc`` instance.  Accepted
 formats (see :func:`find_app_instance`):
 
+- **auto-discovery** -- no ``--app`` scans the current directory and succeeds
+    when exactly one importable Python file defines a ``Pynenc`` instance.
 - **module.attr** -- ``tasks.app`` imports ``tasks`` module, finds the ``Pynenc`` instance.
 - **package.module** -- ``mypackage.tasks`` standard Python import.
 - **file path** -- ``path/to/tasks.py`` loads the file directly.
@@ -20,6 +22,7 @@ import logging
 import os
 import sys
 import types
+from pathlib import Path
 
 from pynenc.app import Pynenc
 from pynenc.app_info import AppInfo
@@ -27,12 +30,13 @@ from pynenc.app_info import AppInfo
 logger = logging.getLogger(__name__)
 
 APP_FORMAT_HELP = (
-    "The --app value must be a dotted path to the module containing your "
-    "Pynenc() instance.\n"
+    "Run from a directory with exactly one importable Python file defining a "
+    "Pynenc() instance, or pass --app explicitly.\n"
     "\n"
     "Examples:\n"
+    "  pynenc runner start                       # auto-discovers a single local app\n"
     "  pynenc --app tasks.app runner start       # loads tasks.py, finds Pynenc instance\n"
-    "  pynenc --app mypackage.tasks runner start  # imports mypackage.tasks\n"
+    "  pynenc --app mypackage.tasks runner start # imports mypackage.tasks\n"
     "  pynenc --app path/to/tasks.py runner start # loads file directly\n"
 )
 
@@ -71,15 +75,118 @@ def _find_pynenc_in_module(module: types.ModuleType) -> Pynenc:
     :return: The first ``Pynenc`` instance found.
     :raises ValueError: If no instance is found.
     """
-    for name in dir(module):
-        obj = getattr(module, name)
-        if isinstance(obj, Pynenc):
-            return obj
+    if instances := _find_pynenc_instances_in_module(module):
+        return instances[0][1]
 
     module_name = getattr(module, "__name__", "unknown")
     raise ValueError(
         f"No Pynenc() instance found in module '{module_name}'.\n"
         f"Make sure the file defines a variable like:  app = Pynenc()\n\n"
+        + APP_FORMAT_HELP
+    )
+
+
+def _find_pynenc_instances_in_module(
+    module: types.ModuleType,
+) -> list[tuple[str, Pynenc]]:
+    """
+    Scan a loaded module for public ``Pynenc`` instances.
+
+    :param types.ModuleType module: The module to scan.
+    :return: ``(variable_name, app)`` pairs, de-duplicated by object identity.
+    """
+    instances: list[tuple[str, Pynenc]] = []
+    seen: set[int] = set()
+    for name in dir(module):
+        if name.startswith("_"):
+            continue
+        try:
+            obj = getattr(module, name)
+        except (AttributeError, ImportError, TypeError):
+            continue
+        except Exception:
+            logger.debug(
+                "Unexpected error while inspecting %s.%s",
+                getattr(module, "__name__", "unknown"),
+                name,
+                exc_info=True,
+            )
+            continue
+        if isinstance(obj, Pynenc) and id(obj) not in seen:
+            seen.add(id(obj))
+            instances.append((name, obj))
+    return instances
+
+
+def _iter_auto_discovery_files() -> list[Path]:
+    """Return top-level Python files to inspect for local app auto-discovery."""
+    cwd = Path(os.getcwd())
+    candidates = [
+        path
+        for path in cwd.glob("*.py")
+        if path.is_file()
+        and not path.name.startswith("_")
+        and path.name not in {"setup.py", "conftest.py"}
+        and _looks_like_pynenc_app_source(path)
+    ]
+
+    preferred_names = {"tasks.py": 0, "app.py": 1, "pynenc_app.py": 2}
+    return sorted(
+        candidates, key=lambda path: (preferred_names.get(path.name, 99), path.name)
+    )
+
+
+def _looks_like_pynenc_app_source(path: Path) -> bool:
+    """Cheaply filter out helper scripts before importing app candidates."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        source = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    return "Pynenc" in source
+
+
+def _find_single_app_in_current_directory() -> Pynenc:
+    """
+    Auto-discover a single local ``Pynenc`` instance.
+
+    This intentionally scans only top-level Python files in the current working
+    directory. If that finds zero or multiple apps, the caller must pass
+    ``--app`` explicitly.
+
+    :return: The discovered ``Pynenc`` instance.
+    :raises ValueError: If discovery finds zero or multiple apps.
+    """
+    discovered: list[tuple[str, str, Pynenc]] = []
+    for path in _iter_auto_discovery_files():
+        try:
+            module = _load_module_from_file(str(path))
+        except Exception as exc:
+            logger.debug("Skipping %s during app auto-discovery: %s", path, exc)
+            continue
+        for variable_name, app in _find_pynenc_instances_in_module(module):
+            discovered.append((path.stem, variable_name, app))
+
+    if len(discovered) == 1:
+        module_name, variable_name, app = discovered[0]
+        logger.info("Auto-discovered Pynenc app at %s.%s", module_name, variable_name)
+        return app
+
+    if not discovered:
+        raise ValueError(
+            "No Pynenc() instance found in the current directory.\n"
+            "Run from the directory that contains your tasks.py/app.py file, "
+            "or specify the app explicitly with --app.\n\n" + APP_FORMAT_HELP
+        )
+
+    locations = "\n".join(
+        f"  - {module}.{variable}" for module, variable, _ in discovered
+    )
+    raise ValueError(
+        "Multiple Pynenc() instances found in the current directory:\n"
+        f"{locations}\n"
+        "Specify the one to use with --app, for example: --app tasks.app\n\n"
         + APP_FORMAT_HELP
     )
 
@@ -196,11 +303,15 @@ def _resolve_dotted_path(app_spec: str) -> types.ModuleType:
 # ---------------------------------------------------------------------------
 
 
-def find_app_instance(app_spec: str | None) -> Pynenc:
+def find_app_instance(app_spec: str | None = None) -> Pynenc:
     """
     Find and load a ``Pynenc`` application instance.
 
-    Accepted ``--app`` formats:
+    If ``app_spec`` is empty, pynenc scans top-level Python files in the
+    current directory and succeeds only when it finds exactly one ``Pynenc``
+    instance.
+
+    Accepted explicit ``--app`` formats:
 
     - ``tasks.app`` -- loads ``tasks.py`` from the current directory,
       scans for a ``Pynenc()`` instance.
@@ -209,10 +320,11 @@ def find_app_instance(app_spec: str | None) -> Pynenc:
 
     :param str | None app_spec: The ``--app`` value from the CLI.
     :return: The ``Pynenc`` application instance.
-    :raises ValueError: If the spec is missing, malformed, or has no Pynenc instance.
+    :raises ValueError: If discovery fails, the spec is malformed, or the target has no Pynenc instance.
     """
     if not app_spec:
-        raise ValueError(f"No --app value provided.\n\n{APP_FORMAT_HELP}")
+        logger.debug("No --app provided; trying local app auto-discovery")
+        return _find_single_app_in_current_directory()
 
     logger.debug("Resolving --app '%s'", app_spec)
     _validate_app_spec(app_spec)

--- a/pynenc_tests/unit/cli/test_main_cli.py
+++ b/pynenc_tests/unit/cli/test_main_cli.py
@@ -50,9 +50,16 @@ def test_cli_with_app() -> None:
             assert "command" in line
 
 
-def test_cli_value_error() -> None:
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["pynenc", "runner", "start"],
+        ["pynenc", "--app", "nonexistent.app", "runner", "start"],
+    ],
+)
+def test_cli_value_error(argv: list[str]) -> None:
     """Test CLI handles ValueError from find_app_instance"""
-    with patch("sys.argv", ["pynenc", "--app", "nonexistent.app", "runner", "start"]):
+    with patch("sys.argv", argv):
         with patch("pynenc.cli.main_cli.find_app_instance") as mock_find_app:
             mock_find_app.side_effect = ValueError("Invalid application module")
             log_capture = StringIO()
@@ -95,3 +102,28 @@ def test_cli_unexpected_exception() -> None:
                     )
                 finally:
                     logging.getLogger().removeHandler(handler)
+
+
+def test_monitor_auto_discovers_local_app() -> None:
+    """Monitor uses local single-app discovery when --app is omitted."""
+    with patch("sys.argv", ["pynenc", "monitor"]):
+        with patch("pynenc.cli.main_cli.find_app_instance", return_value=app):
+            with patch("pynenc.cli.monitor_cli.start_monitor_command") as mock_monitor:
+                main()
+
+    args = mock_monitor.call_args.args[0]
+    assert args.app_instance is app
+    assert args.app == f"auto-discovered app_id={app.app_id}"
+
+
+def test_status_render_does_not_load_app() -> None:
+    """Status rendering inspects the built-in state machine without an app."""
+    with patch("sys.argv", ["pynenc", "status", "render"]):
+        with patch("pynenc.cli.main_cli.find_app_instance") as mock_find_app:
+            with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+                main()
+
+    mock_find_app.assert_not_called()
+    output = mock_stdout.getvalue()
+    assert "START -> REGISTERED" in output
+    assert "PENDING -> FAILED" not in output

--- a/pynenc_tests/unit/cli/test_runner_cli.py
+++ b/pynenc_tests/unit/cli/test_runner_cli.py
@@ -47,3 +47,18 @@ def test_start_runner() -> None:
                 "Starting runner for app: tests.unit.cli.test_runner_cli.app"
             )
         mock_run.assert_called()
+
+
+def test_start_runner_with_auto_discovered_app_label() -> None:
+    """Runner command can print the auto-discovered app label."""
+    args = PynencCLINamespace()
+    args.app = "auto-discovered app_id=test-app"
+    args.app_instance = app
+
+    with patch.object(app.runner, "run", new_callable=MagicMock) as mock_run:
+        with patch("pynenc.cli.runner_cli.print") as mock_print:
+            start_runner_command(args)
+            mock_print.assert_called_with(
+                "Starting runner for app: auto-discovered app_id=test-app"
+            )
+        mock_run.assert_called()

--- a/pynenc_tests/unit/docs/test_invocation_state_machine_svg.py
+++ b/pynenc_tests/unit/docs/test_invocation_state_machine_svg.py
@@ -1,0 +1,34 @@
+import re
+
+from pynenc.invocation.status import InvocationStatus
+from pynenc.invocation.status import _CONFIG
+from pynenc.invocation.status_graph import DEFAULT_OUTPUT_PATH, render_svg
+
+
+def test_invocation_state_machine_svg_is_up_to_date() -> None:
+    assert DEFAULT_OUTPUT_PATH.read_text(encoding="utf-8") == render_svg()
+
+
+def test_invocation_state_machine_svg_contains_all_statuses() -> None:
+    svg = render_svg()
+    for status in InvocationStatus:
+        assert status.name in svg
+
+
+def test_invocation_state_machine_svg_contains_all_transitions() -> None:
+    svg = render_svg()
+    assert 'data-edge="START->REGISTERED"' in svg
+    for source, definition in _CONFIG.definitions.items():
+        if source is None:
+            continue
+        for target in definition.allowed_transitions:
+            assert f'data-edge="{source.name}->{target.name}"' in svg
+
+
+def test_invocation_state_machine_svg_uses_direct_lines() -> None:
+    svg = render_svg()
+    edge_groups = re.findall(r'<g data-edge="[^"]+">\n(.*?)</g>', svg, re.DOTALL)
+    assert edge_groups
+    for group in edge_groups:
+        assert group.count("<line ") == 2
+        assert "<path " not in group

--- a/pynenc_tests/unit/util/test_find_app_instance.py
+++ b/pynenc_tests/unit/util/test_find_app_instance.py
@@ -1,5 +1,7 @@
 """Tests for the find_app_instance entry point."""
 
+import sys
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
@@ -19,14 +21,45 @@ def test_success_via_importlib() -> None:
     assert result is mock_app
 
 
-def test_none_raises_value_error() -> None:
-    with pytest.raises(ValueError, match="No --app value provided"):
-        import_app.find_app_instance(None)  # type: ignore[arg-type]
+def test_none_auto_discovers_single_app(tmp_path: Path) -> None:
+    tasks_file = tmp_path / "tasks.py"
+    tasks_file.write_text("from pynenc import Pynenc\napp = Pynenc()\n")
+
+    with patch("os.getcwd", return_value=str(tmp_path)):
+        result = import_app.find_app_instance(None)
+
+    assert isinstance(result, Pynenc)
+    sys.modules.pop("tasks", None)
 
 
-def test_empty_string_raises_value_error() -> None:
-    with pytest.raises(ValueError, match="No --app value provided"):
-        import_app.find_app_instance("")
+def test_empty_string_auto_discovery_requires_an_app(tmp_path: Path) -> None:
+    with patch("os.getcwd", return_value=str(tmp_path)):
+        with pytest.raises(ValueError, match="No Pynenc.*instance found"):
+            import_app.find_app_instance("")
+
+
+def test_auto_discovery_rejects_multiple_apps(tmp_path: Path) -> None:
+    (tmp_path / "tasks.py").write_text("from pynenc import Pynenc\napp = Pynenc()\n")
+    (tmp_path / "worker.py").write_text("from pynenc import Pynenc\napp = Pynenc()\n")
+
+    with patch("os.getcwd", return_value=str(tmp_path)):
+        with pytest.raises(ValueError, match="Multiple Pynenc.*instances found"):
+            import_app.find_app_instance(None)
+
+    sys.modules.pop("tasks", None)
+    sys.modules.pop("worker", None)
+
+
+def test_auto_discovery_skips_unrelated_scripts(tmp_path: Path) -> None:
+    (tmp_path / "tasks.py").write_text("from pynenc import Pynenc\napp = Pynenc()\n")
+    (tmp_path / "sample.py").write_text("raise RuntimeError('should not import')\n")
+
+    with patch("os.getcwd", return_value=str(tmp_path)):
+        result = import_app.find_app_instance(None)
+
+    assert isinstance(result, Pynenc)
+    assert "sample" not in sys.modules
+    sys.modules.pop("tasks", None)
 
 
 def test_no_pynenc_instance_in_module() -> None:

--- a/pynenc_tests/unit/util/test_import_app_filepath.py
+++ b/pynenc_tests/unit/util/test_import_app_filepath.py
@@ -62,11 +62,13 @@ def test_exec_module_failure_propagates() -> None:
             find_app_instance(SOME_APP_PATH)
 
 
-def test_empty_string_raises() -> None:
-    with pytest.raises(ValueError, match="No --app value provided"):
-        find_app_instance("")
+def test_empty_string_auto_discovery_requires_local_app(tmp_path: Path) -> None:
+    with patch("os.getcwd", return_value=str(tmp_path)):
+        with pytest.raises(ValueError, match="No Pynenc.*instance found"):
+            find_app_instance("")
 
 
-def test_none_input_raises() -> None:
-    with pytest.raises(ValueError, match="No --app value provided"):
-        find_app_instance(None)  # type: ignore[arg-type]
+def test_none_input_auto_discovery_requires_local_app(tmp_path: Path) -> None:
+    with patch("os.getcwd", return_value=str(tmp_path)):
+        with pytest.raises(ValueError, match="No Pynenc.*instance found"):
+            find_app_instance(None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pynenc"
-version = "0.2.2"
+version = "0.2.3"
 description = "A task management system for complex distributed orchestration"
 authors = [{ name = "Luis Diaz", email = "code.luis.diaz@proton.me" }]
 license = { text = "MIT License" }

--- a/uv.lock
+++ b/uv.lock
@@ -775,7 +775,7 @@ wheels = [
 
 [[package]]
 name = "pynenc"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "cistell" },


### PR DESCRIPTION
- Add pynenc status render command (text + SVG) with pre-commit freshness check
- CLI auto-discovers single local Pynenc() instance when --app is omitted
- Add requires_app flag to PynencCLINamespace; status render opts out
- Remove PENDING->FAILED transition; CONCURRENCY_CONTROLLED_FINAL is now final
- Narrow distribute_calls to typed lists with isinstance guards
- Harden multi-thread worker: SIG_IGN on repeated SIGTERM
- Bump version 0.2.2 -> 0.2.3, update changelog and README