### PR TITLE
fix: harden import discovery for dataclass modules and lazy attrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 Pynenc is a Python task orchestration framework for distributed workers. It gives each task invocation a tracked lifecycle, lets the orchestrator enforce concurrency and retry rules, and keeps enough state to inspect what happened after the fact.
 
-## 🆕 What's New in v0.3.0
+## 🆕 What's New in v0.3.1
 
 - **Explicit workflow tasks**: `@app.workflow` now marks the task that defines a workflow or sub-workflow root
 - **Root workflow operations**: deterministic orchestration lives under `wf.root.uuid()`, `wf.root.random()`, `wf.root.utc_now()`, and `wf.root.execute_task(...)`
@@ -407,7 +407,7 @@ pip install pynenc[monitor]
 
 ## Requirements
 
-- **Python 3.11+**
+- **Python 3.12+**
 - **Core package**: No external infrastructure needed — includes memory and SQLite backends for development and testing
 - **Production**: Install a backend plugin (`pynenc-redis`, `pynenc-mongodb`, or `pynenc-rabbitmq`) and ensure the corresponding service is running
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-07-04
+
+### Fixed
+
+- Import discovery now registers modules before execution and scans module
+  dictionaries directly, which makes app detection resilient to dataclass
+  module execution and lazy `__getattr__` side effects.
+
 ## [0.3.0] - 2026-07-01
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Import discovery now registers modules before execution and scans module
   dictionaries directly, which makes app detection resilient to dataclass
   module execution and lazy `__getattr__` side effects.
+- Pynmon status rendering now uses one shared status palette for badges,
+  timeline markers, and status history, so the status views stay visually consistent.
 
 ## [0.3.0] - 2026-07-01
 

--- a/pynenc/util/import_app.py
+++ b/pynenc/util/import_app.py
@@ -218,15 +218,25 @@ def _load_module_from_file(file_path: str) -> types.ModuleType:
         raise ValueError(f"Could not create module spec for '{file_path}'.")
 
     module = importlib.util.module_from_spec(spec)
+    previous_module = sys.modules.get(module_name)
+    sys.modules[module_name] = module
     try:
         spec.loader.exec_module(module)
     except ModuleNotFoundError as exc:
+        if previous_module is None:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = previous_module
         raise ModuleNotFoundError(
             f"Failed to load '{file_path}': {exc}.\n"
             f"Ensure all imports in the file are installed and available."
         ) from exc
-
-    sys.modules[module_name] = module
+    except Exception:
+        if previous_module is None:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = previous_module
+        raise
     return module
 
 
@@ -372,19 +382,14 @@ def _find_app_variable_in_module(module: types.ModuleType, app: "Pynenc") -> str
     :return: Attribute name, or ``None`` if not found.
     """
     try:
-        names = dir(module)
-    except (ImportError, TypeError):
+        attrs = vars(module)
+    except TypeError:
         return None
-    for name in names:
+    for name, value in attrs.items():
         if name.startswith("_"):
             continue
-        try:
-            if getattr(module, name) is app:
-                return name
-        except (AttributeError, TypeError, ImportError):
-            continue
-        except Exception:
-            continue
+        if value is app:
+            return name
     return None
 
 
@@ -472,25 +477,12 @@ def _find_pynenc_by_id_in_module(
     :return: The matching instance, or ``None``.
     """
     try:
-        attrs = dir(module)
-    except (AttributeError, ImportError):
+        attrs = vars(module)
+    except TypeError:
         return None
 
-    for attr_name in attrs:
+    for attr_name, attr in attrs.items():
         if attr_name.startswith("_"):
-            continue
-        try:
-            attr = getattr(module, attr_name)
-        except (AttributeError, TypeError, ImportError):
-            continue
-        except Exception as e:
-            logger.debug(
-                "Unexpected %s accessing %s.%s — skipping",
-                type(e).__name__,
-                mod_name,
-                attr_name,
-                exc_info=True,
-            )
             continue
         if isinstance(attr, Pynenc) and attr.app_id == app_id:
             logger.info("Found app %s in module %s", app_id, mod_name)

--- a/pynenc_tests/unit/pynmon/util/svg/test_status_colors.py
+++ b/pynenc_tests/unit/pynmon/util/svg/test_status_colors.py
@@ -4,7 +4,14 @@ Unit tests for status color mappings.
 Tests that status colors are correctly defined for all common statuses.
 """
 
-from pynmon.util.status_colors import STATUS_COLORS
+from pynmon.util.status_colors import (
+    DEFAULT_STATUS_STYLE,
+    STATUS_BADGE_TEXT_COLOR,
+    STATUS_COLOR_STYLES,
+    STATUS_COLORS,
+    get_hex_color,
+    get_status_colors,
+)
 
 
 def test_all_common_statuses_have_colors() -> None:
@@ -13,3 +20,17 @@ def test_all_common_statuses_have_colors() -> None:
     for status in common_statuses:
         assert status in STATUS_COLORS
         assert STATUS_COLORS[status].startswith("#")
+
+
+def test_retry_uses_the_shared_purple_palette() -> None:
+    """Retry stays purple and gets readable foreground text."""
+    assert STATUS_COLORS["RETRY"] == "#9b59b6"
+    assert STATUS_COLOR_STYLES["RETRY"]["background"] == "#9b59b6"
+    assert DEFAULT_STATUS_STYLE["background"] == "#7f8c8d"
+    assert STATUS_BADGE_TEXT_COLOR == "#ffffff"
+    assert get_hex_color("retry") == "#9b59b6"
+    assert get_hex_color("retrying") == "#9b59b6"
+    assert get_status_colors("retry").hex_color == "#9b59b6"
+    assert get_status_colors("retrying").hex_color == "#9b59b6"
+    assert get_status_colors("retry").text_color == "#ffffff"
+    assert get_status_colors("pending").text_color == "#ffffff"

--- a/pynenc_tests/unit/pynmon/views/test_invocations.py
+++ b/pynenc_tests/unit/pynmon/views/test_invocations.py
@@ -1127,6 +1127,49 @@ def test_invocation_history_endpoint(app: "Pynenc") -> None:
         assert isinstance(data, list)
 
 
+def test_invocation_detail_status_timeline_renders_status_badges(
+    app: "Pynenc",
+) -> None:
+    """The full detail status timeline should show visible status labels."""
+    app.purge()
+    call: Call = Call(add_task, Arguments({"x": 1, "y": 2}))
+    invocation: DistributedInvocation = DistributedInvocation.isolated(call)
+    app.orchestrator.register_new_invocations([invocation])
+    runner_ctx = RunnerContext.from_runner(app.runner)
+    for status in (
+        InvocationStatus.PENDING,
+        InvocationStatus.RUNNING,
+        InvocationStatus.PAUSED,
+    ):
+        app.orchestrator.set_invocation_status(
+            invocation.invocation_id, status, runner_ctx
+        )
+
+    setup_routes()
+
+    with patch("pynmon.views.invocations.get_pynenc_instance", return_value=app):
+        client = TestClient(pynmon_app)
+        detail_response = client.get(f"/invocations/{invocation.invocation_id}")
+        history_response = client.get(
+            f"/invocations/{invocation.invocation_id}/history"
+        )
+
+    assert detail_response.status_code == 200
+    content = detail_response.text
+    assert "Status timeline" in content
+    assert "pynmon-status-badge" in content
+    assert "background-color:" in content
+    assert "color: #ffffff;" in content
+    assert ">PENDING</span" in content
+    assert ">RUNNING</span" in content
+    assert ">PAUSED</span" in content
+
+    assert history_response.status_code == 200
+    history = history_response.json()
+    assert history
+    assert all(entry.get("status") for entry in history)
+
+
 # ################################################################################### #
 # PARAMETRIZED ERROR-CASE TESTS
 # ################################################################################### #

--- a/pynenc_tests/unit/pynmon/views/test_timeline_status_history_rendering.py
+++ b/pynenc_tests/unit/pynmon/views/test_timeline_status_history_rendering.py
@@ -1,0 +1,98 @@
+"""Regression tests for timeline status-history rendering."""
+
+import shutil
+import subprocess
+
+import pytest
+
+from pynmon.app import templates
+
+
+def _extract_between(source: str, start: str, end: str) -> str:
+    """Return the template slice between two marker strings."""
+    start_index = source.index(start)
+    end_index = source.index(end, start_index)
+    return source[start_index:end_index]
+
+
+def test_timeline_status_history_rows_render_status_badges() -> None:
+    """The JS side panel must never render blank status-history cells."""
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required to execute the timeline history renderer")
+    assert node is not None
+
+    rendered = templates.get_template(
+        "invocations/partials/timeline_scripts.html"
+    ).render()
+    helpers = _extract_between(
+        rendered,
+        "  const STATUS_COLOR_STYLES",
+        "  // \u2500\u2500 Cross-highlight helpers",
+    )
+    history_renderer = _extract_between(
+        rendered,
+        "  function buildHistoryRows",
+        "  // \u2500\u2500 Invocation summary card helper",
+    )
+    node_source = "\n".join(
+        [
+            helpers,
+            "function formatUTCDate(value) { return value; }",
+            "function buildRunnerHtml() { return 'runner'; }",
+            history_renderer,
+            """
+const html = buildHistoryRows([
+  { status: "registered", timestamp: "2026-07-04T16:07:35.200Z" },
+  { status: "pending", timestamp: "2026-07-04T16:07:35.216Z" },
+  { status: "running", timestamp: "2026-07-04T16:07:35.230Z" },
+  { status_record: { status: "retry" }, timestamp: "2026-07-04T16:07:35.248Z" },
+  { status: "success", timestamp: "2026-07-04T16:07:35.260Z" },
+  { timestamp: "2026-07-04T16:07:35.251Z" },
+]);
+const expectations = [
+  '>registered</span>',
+  ">pending</span>",
+  ">running</span>",
+  ">retry</span>",
+  ">success</span>",
+  ">unknown</span>",
+  "background-color: #f39c12",
+  "background-color: #3498db",
+  "background-color: #9b59b6",
+  "background-color: #27ae60",
+  "background-color: #7f8c8d",
+];
+for (const expected of expectations) {
+  if (!html.includes(expected)) {
+    throw new Error(`Missing ${expected} in rendered history HTML:\\n${html}`);
+  }
+}
+const badgeMatches = [...html.matchAll(/<span class="badge pynmon-status-badge badge-sm" style="([^"]+)">([^<]+)<\\/span>/g)];
+const expectedText = new Map([
+  ["registered", "background-color: #95a5a6; color: #ffffff;"],
+  ["pending", "background-color: #f39c12; color: #ffffff;"],
+  ["running", "background-color: #3498db; color: #ffffff;"],
+  ["retry", "background-color: #9b59b6; color: #ffffff;"],
+  ["success", "background-color: #27ae60; color: #ffffff;"],
+  ["unknown", "background-color: #7f8c8d; color: #ffffff;"],
+]);
+for (const [label, style] of badgeMatches.map((match) => [match[2], match[1]])) {
+  if (expectedText.get(label) !== style) {
+    throw new Error(`Expected ${label} badge to use white text, got ${style}:\\n${html}`);
+  }
+  expectedText.delete(label);
+}
+if (expectedText.size) {
+  throw new Error(`Missing badges for: ${[...expectedText.keys()].join(", ")}\\n${html}`);
+}
+""",
+        ]
+    )
+
+    subprocess.run(
+        [node, "-e", node_source],
+        check=True,
+        capture_output=True,
+        text=True,
+    )

--- a/pynenc_tests/unit/pynmon/views/test_trigger_run_detail.py
+++ b/pynenc_tests/unit/pynmon/views/test_trigger_run_detail.py
@@ -88,7 +88,7 @@ def test_trigger_run_detail_shows_condition_and_context_details(
     assert "Conditions (" not in response.text
     assert "TriggerCondition" not in response.text
     assert "ConditionContext" not in response.text
-    assert "bg-success" in response.text
+    assert "pynmon-status-badge" in response.text
     assert "SUCCESS" in response.text
     assert "ValidCondition ID" in response.text
     assert condition.condition_id in response.text

--- a/pynenc_tests/unit/util/test_resolve_dotted_path.py
+++ b/pynenc_tests/unit/util/test_resolve_dotted_path.py
@@ -51,6 +51,28 @@ def test_module_registers_in_sys_modules(tmp_path: Path) -> None:
     sys.modules.pop("mymod", None)
 
 
+def test_file_fallback_registers_module_before_execution_for_dataclasses(
+    tmp_path: Path,
+) -> None:
+    """Dataclass decoration needs the executing module present in sys.modules."""
+    tasks_file = tmp_path / "dataclass_tasks.py"
+    tasks_file.write_text(
+        "from dataclasses import dataclass\n"
+        "from pynenc import Pynenc\n"
+        "@dataclass(frozen=True)\n"
+        "class Order:\n"
+        "    order_id: str\n"
+        "app = Pynenc()\n"
+    )
+
+    with patch("os.getcwd", return_value=str(tmp_path)):
+        with patch("importlib.import_module", side_effect=ModuleNotFoundError):
+            result = import_app.find_app_instance("dataclass_tasks.app")
+
+    assert isinstance(result, Pynenc)
+    sys.modules.pop("dataclass_tasks", None)
+
+
 def test_file_dir_added_to_sys_path(tmp_path: Path) -> None:
     """The file's directory should be added to sys.path."""
     tasks_file = tmp_path / "pathmod.py"

--- a/pynenc_tests/unit/util/test_scan_modules_resilience.py
+++ b/pynenc_tests/unit/util/test_scan_modules_resilience.py
@@ -7,6 +7,7 @@ exceptions from lazy-loading modules (e.g. ``six.moves`` triggering
 
 import logging
 import types
+import warnings
 from unittest.mock import patch
 
 import pytest
@@ -57,6 +58,31 @@ def test_finds_matching_app_id() -> None:
 
     result = import_app._find_pynenc_by_id_in_module(module, "good_mod", app.app_id)
     assert result is app
+
+
+def test_module_scan_does_not_touch_lazy_deprecated_attrs() -> None:
+    """Scanning module dictionaries must not trigger module-level __getattr__ warnings."""
+    app = Pynenc()
+
+    class DeprecatedAttrsModule(types.ModuleType):
+        def __getattr__(self, name: str) -> object:
+            warnings.warn(f"{name} is deprecated", DeprecationWarning, stacklevel=2)
+            raise AttributeError(name)
+
+    module = DeprecatedAttrsModule("deprecated_attrs_mod")
+    module.app = app  # type: ignore[attr-defined]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        var_name = import_app._find_app_variable_in_module(module, app)
+        found_app = import_app._find_pynenc_by_id_in_module(
+            module,
+            "deprecated_attrs_mod",
+            app.app_id,
+        )
+
+    assert var_name == "app"
+    assert found_app is app
 
 
 def test_skips_non_matching_app_id() -> None:

--- a/pynmon/app.py
+++ b/pynmon/app.py
@@ -20,6 +20,13 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from pynenc.app import AppInfo, Pynenc
+from pynmon.util.status_colors import (
+    DEFAULT_STATUS_STYLE,
+    STATUS_BADGE_TEXT_COLOR,
+    STATUS_COLORS,
+    STATUS_COLOR_STYLES,
+    get_status_colors,
+)
 
 
 # Standard library pattern: add NullHandler so that libraries using pynmon
@@ -30,6 +37,7 @@ from pynenc.app import AppInfo, Pynenc
 logging.getLogger("pynmon").addHandler(logging.NullHandler())
 
 logger = logging.getLogger("pynmon")
+STATIC_ASSET_VERSION = "20260704-status-badge-white"
 
 
 def configure_logging(log_level: str = "INFO") -> None:
@@ -163,6 +171,14 @@ app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 # Set up Jinja2 templates
 templates_dir = Path(__file__).parent / "templates"
 templates = Jinja2Templates(directory=str(templates_dir))
+templates.env.globals.update(
+    DEFAULT_STATUS_STYLE=DEFAULT_STATUS_STYLE,
+    STATIC_ASSET_VERSION=STATIC_ASSET_VERSION,
+    STATUS_BADGE_TEXT_COLOR=STATUS_BADGE_TEXT_COLOR,
+    STATUS_COLORS=STATUS_COLORS,
+    STATUS_COLOR_STYLES=STATUS_COLOR_STYLES,
+    get_status_colors=get_status_colors,
+)
 
 # Global reference to the monitored Pynenc app instance.
 all_pynenc_instances: dict[str, Pynenc] = {}

--- a/pynmon/static/css/invocations.css
+++ b/pynmon/static/css/invocations.css
@@ -31,6 +31,10 @@
   top: 0;
 }
 
+.pynmon-status-marker {
+  background-color: var(--pynmon-status-bg, #7f8c8d);
+}
+
 .timeline-content {
   padding-bottom: 10px;
 }

--- a/pynmon/static/css/pynmon.css
+++ b/pynmon/static/css/pynmon.css
@@ -227,6 +227,17 @@ body {
   font-weight: 500;
 }
 
+.badge-sm {
+  font-size: 9px;
+}
+
+.pynmon-status-badge {
+  background-color: var(--pynmon-status-bg, var(--bs-secondary));
+  color: #ffffff !important;
+  font-weight: 700;
+  line-height: 1;
+}
+
 .bg-success {
   background-color: var(--success-green) !important;
 }

--- a/pynmon/templates/base.html
+++ b/pynmon/templates/base.html
@@ -21,10 +21,22 @@
     />
 
     <!-- Custom Pynmon CSS -->
-    <link href="/static/css/pynmon.css" rel="stylesheet" />
-    <link href="/static/css/timeline.css" rel="stylesheet" />
-    <link href="/static/css/arguments.css" rel="stylesheet" />
-    <link href="/static/css/invocations.css" rel="stylesheet" />
+    <link
+      href="/static/css/pynmon.css?v={{ STATIC_ASSET_VERSION }}"
+      rel="stylesheet"
+    />
+    <link
+      href="/static/css/timeline.css?v={{ STATIC_ASSET_VERSION }}"
+      rel="stylesheet"
+    />
+    <link
+      href="/static/css/arguments.css?v={{ STATIC_ASSET_VERSION }}"
+      rel="stylesheet"
+    />
+    <link
+      href="/static/css/invocations.css?v={{ STATIC_ASSET_VERSION }}"
+      rel="stylesheet"
+    />
     {% block extra_css %}{% endblock %}
 
     <!-- HTMX for dynamic updates -->

--- a/pynmon/templates/invocations/detail.html
+++ b/pynmon/templates/invocations/detail.html
@@ -327,14 +327,9 @@ text[:22] }}...{{ text[-12:] }}{% else %}{{ text }}{% endif %} {%- endmacro %}
                       <div class="inv-summary-task">{{ s.func_name }}</div>
                       {% endif %}
                       <div class="inv-summary-meta">
-                        {% if s.get("status") %}
-                        <span
-                          class="badge {% if s.status == 'SUCCESS' %}bg-success{% elif s.status == 'FAILED' %}bg-danger{% elif s.status == 'RUNNING' %}bg-primary{% else %}bg-secondary{% endif %}"
-                          style="font-size: 9px"
-                          >{{ s.status }}</span
-                        >
-                        {% endif %} {% if s.get("duration_seconds") is not none
-                        %}
+                        {% if s.get("status") %} {{ status_badge(s.status,
+                        'small') }} {% endif %} {% if s.get("duration_seconds")
+                        is not none %}
                         <span class="inv-summary-duration"
                           >{{ "%.2f"|format(s.duration_seconds) }}s</span
                         >
@@ -405,14 +400,9 @@ text[:22] }}...{{ text[-12:] }}{% else %}{{ text }}{% endif %} {%- endmacro %}
                           <div class="inv-summary-task">{{ s.func_name }}</div>
                           {% endif %}
                           <div class="inv-summary-meta">
-                            {% if s.get("status") %}
-                            <span
-                              class="badge {% if s.status == 'SUCCESS' %}bg-success{% elif s.status == 'FAILED' %}bg-danger{% elif s.status == 'RUNNING' %}bg-primary{% else %}bg-secondary{% endif %}"
-                              style="font-size: 9px"
-                              >{{ s.status }}</span
-                            >
-                            {% endif %} {% if s.get("duration_seconds") is not
-                            none %}
+                            {% if s.get("status") %} {{ status_badge(s.status,
+                            'small') }} {% endif %} {% if
+                            s.get("duration_seconds") is not none %}
                             <span class="inv-summary-duration"
                               >{{ "%.2f"|format(s.duration_seconds) }}s</span
                             >
@@ -510,17 +500,9 @@ text[:22] }}...{{ text[-12:] }}{% else %}{{ text }}{% endif %} {%- endmacro %}
                           <div class="inv-summary-task">{{ s.func_name }}</div>
                           {% endif %}
                           <div class="inv-summary-meta">
-                            {% if s.status %} {% set status_class = { 'SUCCESS':
-                            'bg-success', 'FAILED': 'bg-danger', 'RUNNING':
-                            'bg-primary', 'PENDING': 'bg-secondary', 'RETRYING':
-                            'bg-warning text-dark', }.get(s.status,
-                            'bg-secondary') %}
-                            <span
-                              class="badge {{ status_class }}"
-                              style="font-size: 9px"
-                              >{{ s.status }}</span
-                            >
-                            {% endif %} {% if s.duration_seconds is not none %}
+                            {% if s.status %} {{ status_badge(s.status, 'small')
+                            }} {% endif %} {% if s.duration_seconds is not none
+                            %}
                             <span class="inv-summary-duration"
                               >{{ "%.2f"|format(s.duration_seconds) }}s</span
                             >
@@ -606,14 +588,9 @@ text[:22] }}...{{ text[-12:] }}{% else %}{{ text }}{% endif %} {%- endmacro %}
                         <div class="inv-summary-task">{{ s.func_name }}</div>
                         {% endif %}
                         <div class="inv-summary-meta">
-                          {% if s.get("status") %}
-                          <span
-                            class="badge {% if s.status == 'SUCCESS' %}bg-success{% elif s.status == 'FAILED' %}bg-danger{% elif s.status == 'RUNNING' %}bg-primary{% else %}bg-secondary{% endif %}"
-                            style="font-size: 9px"
-                            >{{ s.status }}</span
-                          >
-                          {% endif %} {% if s.get("duration_seconds") is not
-                          none %}
+                          {% if s.get("status") %} {{ status_badge(s.status,
+                          'small') }} {% endif %} {% if
+                          s.get("duration_seconds") is not none %}
                           <span class="inv-summary-duration"
                             >{{ "%.2f"|format(s.duration_seconds) }}s</span
                           >
@@ -693,14 +670,9 @@ text[:22] }}...{{ text[-12:] }}{% else %}{{ text }}{% endif %} {%- endmacro %}
                             </div>
                             {% endif %}
                             <div class="inv-summary-meta">
-                              {% if s.get("status") %}
-                              <span
-                                class="badge {% if s.status == 'SUCCESS' %}bg-success{% elif s.status == 'FAILED' %}bg-danger{% elif s.status == 'RUNNING' %}bg-primary{% else %}bg-secondary{% endif %}"
-                                style="font-size: 9px"
-                                >{{ s.status }}</span
-                              >
-                              {% endif %} {% if s.get("duration_seconds") is not
-                              none %}
+                              {% if s.get("status") %} {{ status_badge(s.status,
+                              'small') }} {% endif %} {% if
+                              s.get("duration_seconds") is not none %}
                               <span class="inv-summary-duration"
                                 >{{ "%.2f"|format(s.duration_seconds) }}s</span
                               >
@@ -790,12 +762,15 @@ text[:22] }}...{{ text[-12:] }}{% else %}{{ text }}{% endif %} {%- endmacro %}
             <div class="timeline compact-timeline">
               {% for entry in history %}
               <div class="timeline-item compact-timeline-item">
+                {% set entry_status = entry.get("status") or 'unknown' %} {% set
+                marker_colors = get_status_colors(entry_status) %}
                 <div
-                  class="timeline-marker {% if entry.status == 'SUCCESS' %}bg-success{% elif entry.status == 'FAILED' %}bg-danger{% elif entry.status == 'RUNNING' %}bg-info{% elif entry.status == 'PENDING' %}bg-warning{% elif entry.status == 'PAUSED' %}bg-primary{% elif entry.status == 'RETRY' %}bg-secondary{% else %}bg-dark{% endif %}"
+                  class="timeline-marker pynmon-status-marker"
+                  style="background-color: {{ marker_colors.hex_color }};"
                 ></div>
                 <div class="timeline-content compact-timeline-content">
                   <div class="timeline-title compact-timeline-title">
-                    {{ status_badge(entry.status) }}
+                    {{ status_badge(entry_status) }}
                   </div>
                   <div class="timeline-date metadata-text">
                     {{ entry.timestamp }}

--- a/pynmon/templates/invocations/partials/timeline_scripts.html
+++ b/pynmon/templates/invocations/partials/timeline_scripts.html
@@ -13,6 +13,63 @@
     currentX: 0,
     suppressNextClick: false,
   };
+  const STATUS_COLOR_STYLES = {{ STATUS_COLOR_STYLES | tojson }};
+  const DEFAULT_STATUS_STYLE = {{ DEFAULT_STATUS_STYLE | tojson }};
+  const STATUS_BADGE_TEXT_COLOR = {{ STATUS_BADGE_TEXT_COLOR | tojson }};
+
+  function normalizeStatusName(status) {
+    const value = String(status ?? "").trim().toUpperCase();
+    return value === "RETRYING" ? "RETRY" : value;
+  }
+
+  function getStatusStyle(status) {
+    return (
+      STATUS_COLOR_STYLES[normalizeStatusName(status)] || DEFAULT_STATUS_STYLE
+    );
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? "").replace(/[&<>"']/g, (char) => {
+      const escaped = {
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      }[char];
+      return escaped || char;
+    });
+  }
+
+  function getStatusBadgeStyle(status) {
+    const colors = getStatusStyle(status);
+    return `background-color: ${colors.background}; color: ${STATUS_BADGE_TEXT_COLOR};`;
+  }
+
+  function renderStatusBadge(status, size = "normal", label = null) {
+    const sizeClass = size === "small" ? " badge-sm" : "";
+    const displayLabel = label ?? status ?? "";
+    return `<span class="badge pynmon-status-badge${sizeClass}" style="${getStatusBadgeStyle(
+      status
+    )}">${escapeHtml(displayLabel)}</span>`;
+  }
+
+  function getHistoryStatus(entry) {
+    return (
+      entry?.status ??
+      entry?.status_name ??
+      entry?.statusName ??
+      entry?.status_record?.status ??
+      entry?.statusRecord?.status ??
+      ""
+    );
+  }
+
+  function renderHistoryStatusBadge(entry) {
+    const status = String(getHistoryStatus(entry) ?? "").trim();
+    const displayLabel = status ? status.toLowerCase() : "unknown";
+    return renderStatusBadge(status || "unknown", "small", displayLabel);
+  }
 
   // ── Cross-highlight helpers ──────────────────────────────────────────
   // Highlight / unhighlight an invocation across BOTH the timeline SVG
@@ -689,9 +746,7 @@
     if (historyData?.length > 0) {
       const last = historyData[historyData.length - 1];
       html += `<tr><th>Status</th>
-        <td><span class="badge bg-${getStatusClass(
-          last.status
-        )}">${last.status.toLowerCase()}</span></td></tr>
+        <td>${renderHistoryStatusBadge(last)}</td></tr>
         <tr><th>Duration</th><td>${calculateDuration(historyData)}</td></tr>`;
     }
 
@@ -759,9 +814,7 @@
 
     historyData.forEach((h) => {
       html += `<tr>
-        <td><span class="badge bg-${getStatusClass(
-          h.status
-        )}">${h.status.toLowerCase()}</span></td>
+        <td>${renderHistoryStatusBadge(h)}</td>
         <td style="font-size:11px;">${formatUTCDate(h.timestamp)}</td>
         <td style="font-size:11px;">${buildRunnerHtml(h)}</td>
       </tr>`;
@@ -779,14 +832,6 @@
     const status = summary?.status || "";
     const dur = summary?.duration_seconds;
     const durTxt = dur != null ? `${dur.toFixed(2)}s` : "";
-    const statusClass =
-      {
-        SUCCESS: "bg-success",
-        FAILED: "bg-danger",
-        RUNNING: "bg-primary",
-        PENDING: "bg-secondary",
-        RETRYING: "bg-warning text-dark",
-      }[status] || "bg-secondary";
     const clickAttrs = runId
       ? `data-invocation-id="${invId}" data-trigger-run-id="${runId}"`
       : `data-invocation-id="${invId}"`;
@@ -799,7 +844,7 @@
       <div class="inv-summary-meta">
         ${
           status
-            ? `<span class="badge ${statusClass}" style="font-size:9px;">${status}</span>`
+            ? renderStatusBadge(status, "small", status)
             : ""
         }
         ${durTxt ? `<span class="inv-summary-duration">${durTxt}</span>` : ""}
@@ -1577,25 +1622,6 @@
         console.error("Error loading event details:", err);
         content.innerHTML = `<div class="alert alert-danger mb-0">Error loading event: ${err.message}</div>`;
       });
-  }
-
-  function getStatusClass(status) {
-    const map = {
-      REGISTERED: "secondary",
-      PENDING: "warning",
-      RUNNING: "info",
-      SUCCESS: "success",
-      FAILED: "danger",
-      RETRY: "secondary",
-      PAUSED: "primary",
-      REROUTED: "info",
-      CONCURRENCY_CONTROLLED: "warning",
-      CONCURRENCY_CONTROLLED_FINAL: "warning",
-      CANCELLED: "dark",
-      TIMEOUT: "danger",
-      SCHEDULED: "warning",
-    };
-    return map[(status || "").toUpperCase()] || "secondary";
   }
 
   function formatUTCDate(isoString) {

--- a/pynmon/templates/partials/status_badge.html
+++ b/pynmon/templates/partials/status_badge.html
@@ -1,26 +1,16 @@
-{# Unified status badge macro for consistent styling across pynmon #} {# Uses
-colors that match the SVG timeline status colors #} {% macro
-status_badge(status, size='normal') %} {# Render a status badge with unified
-colors matching the timeline SVG. Args: status: The status string (can be
-uppercase or lowercase) size: 'normal' or 'small' for font sizing Usage: {% from
-"partials/status_badge.html" import status_badge %} {{
-status_badge(invocation.status.name) }} {{ status_badge('RUNNING', 'small') }}
-#} {% set status_upper = status|upper if status is string else status.name|upper
-%} {% set badge_class = { 'REGISTERED': 'secondary', 'PENDING': 'warning',
-'RUNNING': 'info', 'SUCCESS': 'success', 'FAILED': 'danger', 'RETRY':
-'secondary', 'PAUSED': 'primary', 'CONCURRENCY_CONTROLLED': 'warning',
-'CONCURRENCY_CONTROLLED_FINAL': 'warning', 'CANCELLED': 'dark', 'TIMEOUT':
-'danger', 'SCHEDULED': 'warning', 'REROUTED': 'info' }.get(status_upper,
-'secondary') %} {% set size_class = 'badge-sm' if size == 'small' else '' %}
-<span class="badge bg-{{ badge_class }} {{ size_class }}"
-  >{{ status_upper }}</span
+{# Unified status badge macro for consistent styling across pynmon. The status
+palette lives in pynmon.util.status_colors and is injected by pynmon.app. #} {%
+macro status_badge(status, size='normal') -%} {% set raw_status = status if
+status is not none else 'unknown' %} {% set status_name = raw_status if
+raw_status is string else raw_status.name|default(raw_status|string, true) %} {%
+set status_label = status_name|string|trim %} {% set status_label = status_label
+if status_label else 'unknown' %} {% set colors =
+get_status_colors(status_label) %} {% set size_class = 'badge-sm' if size ==
+'small' else '' %}
+<span
+  class="badge pynmon-status-badge {{ size_class }}"
+  style="background-color: {{ colors.hex_color }}; color: {{ STATUS_BADGE_TEXT_COLOR }};"
+  >{{ status_label|upper }}</span
 >
-{% endmacro %} {% macro status_color(status) %} {# Get the hex color for a
-status (for inline styles or SVG). Args: status: The status string Returns: Hex
-color string #} {% set status_upper = status|upper if status is string else
-status.name|upper %} {{ { 'REGISTERED': '#95a5a6', 'PENDING': '#f39c12',
-'RUNNING': '#3498db', 'SUCCESS': '#27ae60', 'FAILED': '#e74c3c', 'RETRY':
-'#9b59b6', 'PAUSED': '#1abc9c', 'CONCURRENCY_CONTROLLED': '#e67e22',
-'CONCURRENCY_CONTROLLED_FINAL': '#d35400', 'CANCELLED': '#7f8c8d', 'TIMEOUT':
-'#c0392b', 'SCHEDULED': '#f1c40f', 'REROUTED': '#16a085' }.get(status_upper,
-'#7f8c8d') }} {% endmacro %}
+{%- endmacro %} {% macro status_color(status) -%} {{
+get_status_colors(status).hex_color }} {%- endmacro %}

--- a/pynmon/util/status_colors.py
+++ b/pynmon/util/status_colors.py
@@ -1,8 +1,9 @@
 """
 Unified status color definitions for pynmon.
 
-This module provides consistent color mappings for invocation statuses across
-all pynmon components including SVG timelines, HTML templates, and JavaScript.
+This module is the canonical palette for invocation statuses across SVG, HTML
+and JavaScript renderers. The status-to-background mapping lives in one place,
+and status badges use one shared white foreground for readability.
 
 The color scheme follows a semantic approach:
 - Neutral states: Gray tones (REGISTERED, REROUTED)
@@ -18,12 +19,12 @@ Status visualization types:
 
 Key components:
 - STATUS_COLORS: Hex color mapping for SVG/CSS
-- STATUS_BOOTSTRAP_CLASSES: Bootstrap class mapping for HTML templates
 - SEGMENT_STATUSES: Statuses that occupy worker and show as segments
 - OUTCOME_STATUSES: Final execution outcomes that color the preceding segment
 """
 
 from dataclasses import dataclass
+from typing import Any
 
 
 # Hex color mapping for SVG and CSS direct styling
@@ -45,6 +46,7 @@ STATUS_COLORS: dict[str, str] = {
 }
 
 DEFAULT_STATUS_COLOR = "#7f8c8d"  # Gray for unknown statuses
+STATUS_BADGE_TEXT_COLOR = "#ffffff"
 
 
 # Statuses that occupy a worker and should be shown as segments (duration bars)
@@ -74,76 +76,66 @@ OUTCOME_STATUSES: frozenset[str] = frozenset(
     }
 )
 
-# Bootstrap class mapping for HTML template badges
-# Using bg-* classes for consistent Bootstrap 5 styling
-STATUS_BOOTSTRAP_CLASSES: dict[str, str] = {
-    "REGISTERED": "secondary",
-    "CONCURRENCY_CONTROLLED": "warning",
-    "CONCURRENCY_CONTROLLED_FINAL": "warning",
-    "REROUTED": "info",
-    "PENDING": "warning",
-    "PENDING_RECOVERY": "warning",
-    "RUNNING": "info",
-    "RUNNING_RECOVERY": "warning",
-    "PAUSED": "primary",
-    "KILLED": "danger",
-    "SUCCESS": "success",
-    "FAILED": "danger",
-    "RETRY": "secondary",
-}
-
-DEFAULT_BOOTSTRAP_CLASS = "secondary"
-
 
 @dataclass(frozen=True)
 class StatusColors:
     """
     Status color information for a specific status.
 
-    Provides both hex colors for SVG/CSS and Bootstrap classes for templates.
+    Provides the background color plus the foreground color used for badges.
 
     :param str hex_color: Hex color string (e.g., "#3498db")
-    :param str bootstrap_class: Bootstrap class name (e.g., "info")
+    :param str text_color: Shared foreground color for status badges.
     """
 
     hex_color: str
-    bootstrap_class: str
+    text_color: str
 
 
-def get_status_colors(status: str) -> StatusColors:
+def _normalize_status_name(status: Any) -> str:
+    """Return a canonical status name for color lookups."""
+    if status is None:
+        return ""
+    if hasattr(status, "name"):
+        status = status.name
+
+    status_upper = str(status).strip().upper()
+    # Some UI surfaces use RETRYING as a display-only label; normalize it to
+    # RETRY so both timeline and status-history views share the same purple.
+    return "RETRY" if status_upper == "RETRYING" else status_upper
+
+
+STATUS_COLOR_STYLES: dict[str, dict[str, str]] = {
+    status: {"background": hex_color} for status, hex_color in STATUS_COLORS.items()
+}
+DEFAULT_STATUS_STYLE: dict[str, str] = {
+    "background": DEFAULT_STATUS_COLOR,
+}
+
+
+def get_status_colors(status: Any) -> StatusColors:
     """
     Get color information for a status.
 
-    :param str status: Status name (case-insensitive)
-    :return: StatusColors with hex and bootstrap values
+    :param status: Status name or enum-like object (case-insensitive)
+    :return: StatusColors with background and contrast values
     """
-    status_upper = status.upper()
+    status_upper = _normalize_status_name(status)
+    style = STATUS_COLOR_STYLES.get(status_upper, DEFAULT_STATUS_STYLE)
     return StatusColors(
-        hex_color=STATUS_COLORS.get(status_upper, DEFAULT_STATUS_COLOR),
-        bootstrap_class=STATUS_BOOTSTRAP_CLASSES.get(
-            status_upper, DEFAULT_BOOTSTRAP_CLASS
-        ),
+        hex_color=style["background"],
+        text_color=STATUS_BADGE_TEXT_COLOR,
     )
 
 
-def get_hex_color(status: str) -> str:
+def get_hex_color(status: Any) -> str:
     """
     Get hex color for a status.
 
-    :param str status: Status name (case-insensitive)
+    :param status: Status name or enum-like object (case-insensitive)
     :return: Hex color string
     """
-    return STATUS_COLORS.get(status.upper(), DEFAULT_STATUS_COLOR)
-
-
-def get_bootstrap_class(status: str) -> str:
-    """
-    Get Bootstrap class for a status.
-
-    :param str status: Status name (case-insensitive)
-    :return: Bootstrap class name (without 'bg-' prefix)
-    """
-    return STATUS_BOOTSTRAP_CLASSES.get(status.upper(), DEFAULT_BOOTSTRAP_CLASS)
+    return STATUS_COLORS.get(_normalize_status_name(status), DEFAULT_STATUS_COLOR)
 
 
 def is_segment_status(status: str) -> bool:
@@ -156,7 +148,7 @@ def is_segment_status(status: str) -> bool:
     :param str status: Status name (case-insensitive)
     :return: True if status should be a segment, False for point-only
     """
-    return status.upper() in SEGMENT_STATUSES
+    return _normalize_status_name(status) in SEGMENT_STATUSES
 
 
 def is_point_only_status(status: str) -> bool:
@@ -166,59 +158,4 @@ def is_point_only_status(status: str) -> bool:
     :param str status: Status name (case-insensitive)
     :return: True if status is point-only, False if segment
     """
-    return status.upper() in POINT_ONLY_STATUSES
-
-
-# JavaScript constants for client-side status color mapping
-# This string can be included in templates
-JS_STATUS_COLORS = """
-const STATUS_COLORS = {
-  'REGISTERED': '#95a5a6',
-  'CONCURRENCY_CONTROLLED': '#e67e22',
-  'CONCURRENCY_CONTROLLED_FINAL': '#d35400',
-  'REROUTED': '#16a085',
-  'PENDING': '#f39c12',
-  'PENDING_RECOVERY': '#e67e22',
-  'RUNNING': '#3498db',
-  'RUNNING_RECOVERY': '#e67e22',
-  'PAUSED': '#1abc9c',
-  'KILLED': '#c0392b',
-  'SUCCESS': '#27ae60',
-  'FAILED': '#e74c3c',
-  'RETRY': '#9b59b6'
-};
-
-const STATUS_BOOTSTRAP_CLASSES = {
-  'REGISTERED': 'secondary',
-  'CONCURRENCY_CONTROLLED': 'warning',
-  'CONCURRENCY_CONTROLLED_FINAL': 'warning',
-  'REROUTED': 'info',
-  'PENDING': 'warning',
-  'PENDING_RECOVERY': 'warning',
-  'RUNNING': 'info',
-  'RUNNING_RECOVERY': 'warning',
-  'PAUSED': 'primary',
-  'KILLED': 'danger',
-  'SUCCESS': 'success',
-  'FAILED': 'danger',
-  'RETRY': 'secondary'
-};
-
-// Statuses that occupy worker time (rendered as segments)
-const SEGMENT_STATUSES = new Set(['RUNNING', 'PENDING']);
-
-// Statuses that are instantaneous (rendered as points)
-const POINT_ONLY_STATUSES = new Set(Object.keys(STATUS_COLORS).filter(s => !SEGMENT_STATUSES.has(s)));
-
-function getStatusClass(status) {
-  return STATUS_BOOTSTRAP_CLASSES[status] || 'secondary';
-}
-
-function getStatusColor(status) {
-  return STATUS_COLORS[status] || '#7f8c8d';
-}
-
-function isSegmentStatus(status) {
-  return SEGMENT_STATUSES.has(status);
-}
-"""
+    return _normalize_status_name(status) in POINT_ONLY_STATUSES

--- a/pynmon/views/trigger_runs.py
+++ b/pynmon/views/trigger_runs.py
@@ -7,6 +7,7 @@ import json
 import logging
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
+from collections.abc import Sequence
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, Request
@@ -34,6 +35,96 @@ def _shorten_id(value: str, *, head: int = 22, tail: int = 12) -> str:
     if len(value) <= head + tail + 1:
         return value
     return f"{value[:head]}...{value[-tail:]}"
+
+
+def _parse_context_summary(summary: str) -> dict[str, str]:
+    """Parse a compact ``key:value`` summary string into a token map."""
+    tokens: dict[str, str] = {}
+    for token in summary.split():
+        if ":" not in token:
+            continue
+        key, value = token.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or not value or key in tokens:
+            continue
+        tokens[key] = value
+    return tokens
+
+
+def _context_summary_items(summary: str) -> list[dict[str, Any]]:
+    """Build detail rows from a compact participant context summary."""
+    tokens = _parse_context_summary(summary)
+    items: list[dict[str, Any]] = []
+
+    status = tokens.get("status")
+    if status:
+        items.append(
+            {
+                "key": "statuses",
+                "label": "Status",
+                "render": "status_badges",
+                "statuses": [status.upper()],
+            }
+        )
+
+    task_id_key = tokens.get("task")
+    if task_id_key:
+        items.append(
+            {
+                "key": "task",
+                "label": "Task",
+                "value": task_id_key,
+                "multiline": False,
+                "render": "value",
+            }
+        )
+
+    exception_type = tokens.get("exception")
+    if exception_type:
+        items.append(
+            {
+                "key": "exception",
+                "label": "Exception",
+                "value": exception_type,
+                "multiline": False,
+                "render": "value",
+            }
+        )
+
+    return items
+
+
+def _source_inv_summary_from_participant(participant: object) -> dict[str, Any]:
+    """Build a lightweight invocation summary from participant snapshot data."""
+    context_summary = str(getattr(participant, "context_summary", "") or "")
+    tokens = _parse_context_summary(context_summary)
+    status = tokens.get("status")
+    if not status:
+        return {}
+
+    summary: dict[str, Any] = {"status": status.upper()}
+    task_id_key = tokens.get("task")
+    if task_id_key:
+        summary["task_id_key"] = task_id_key
+        summary["func_name"] = task_id_key.rsplit(".", 1)[-1]
+    return summary
+
+
+def _fill_source_invocation_summaries(
+    source_inv_summaries: dict[str, dict[str, Any]],
+    participants: Sequence[Any],
+) -> None:
+    """Backfill source-invocation summaries from participant snapshots."""
+    for participant in participants:
+        source_invocation_id = getattr(participant, "source_invocation_id", None)
+        if not source_invocation_id:
+            continue
+        if source_inv_summaries.get(source_invocation_id):
+            continue
+        fallback = _source_inv_summary_from_participant(participant)
+        if fallback:
+            source_inv_summaries[source_invocation_id] = fallback
 
 
 def _json_safe(value: Any) -> Any:
@@ -200,6 +291,15 @@ def _context_view_from_participant(
                         "emitted_by_invocation_id": event.emitted_by_invocation_id,
                     }
                 )
+            )
+    if summary:
+        summary_items = _context_summary_items(summary)
+        if summary_items:
+            existing_keys = {
+                str(item.get("key")) for item in items if item.get("key") is not None
+            }
+            items.extend(
+                item for item in summary_items if item["key"] not in existing_keys
             )
     return {
         "available": available,
@@ -425,6 +525,9 @@ async def trigger_run_api(trigger_run_id: str) -> JSONResponse:
         invocation_id: await asyncio.to_thread(_fetch_inv_summary, app, invocation_id)
         for invocation_id in invocation_ids
     }
+    _fill_source_invocation_summaries(
+        payload["invocation_summaries"], run.participants or []
+    )
     events: list[dict] = []
     event_timestamps: list[datetime] = []
     for event_id in run.event_ids or []:
@@ -492,6 +595,7 @@ async def trigger_run_detail(request: Request, trigger_run_id: str) -> HTMLRespo
     source_inv_summaries = {
         sid: await asyncio.to_thread(_fetch_inv_summary, app, sid) for sid in src_ids
     }
+    _fill_source_invocation_summaries(source_inv_summaries, run.participants or [])
 
     # Collect rich summaries for every event referenced on the run so the
     # Outcome panel can render pills with code + timestamp + outcome state.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pynenc"
-version = "0.3.0"
+version = "0.3.1"
 description = "A task management system for complex distributed orchestration"
 authors = [{ name = "Luis Diaz", email = "code.luis.diaz@proton.me" }]
 license = { text = "MIT License" }

--- a/uv.lock
+++ b/uv.lock
@@ -775,7 +775,7 @@ wheels = [
 
 [[package]]
 name = "pynenc"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "cistell" },


### PR DESCRIPTION
Import discovery now registers modules before execution and scans module dictionaries directly, which makes app detection resilient to dataclass module execution and lazy `__getattr__` side effects.